### PR TITLE
Merge pulp_packaging Ansible roles and playbooks

### DIFF
--- a/ansible/dev-playbook.yml
+++ b/ansible/dev-playbook.yml
@@ -9,4 +9,4 @@
     - qpidd
     - dev
     - lazy
-    - pulp_ca
+    - pulp-certs

--- a/ansible/roles/lazy/files/squid-3.1.conf
+++ b/ansible/roles/lazy/files/squid-3.1.conf
@@ -2,7 +2,13 @@
 # matters in Squid's configuration; the configuration is applied top to bottom.
 
 # Listen on port 3128 in Accelerator (caching) mode.
-http_port 3128 accel
+http_port 3128 accel defaultsite=127.0.0.1:8751
+
+# Squid 3.1 doesn't define these Access Control Lists by default. RHEL/CentOS 6
+# users should uncomment the following acl definitions.
+acl manager proto cache_object
+acl localhost src 127.0.0.1/32 ::1
+acl to_localhost dst 127.0.0.0/8 0.0.0.0/32 ::1
 
 # Only accept connections from the local host. If the Apache reverse proxy is
 # running on a different host, adjust this accordingly.

--- a/ansible/roles/lazy/tasks/main.yml
+++ b/ansible/roles/lazy/tasks/main.yml
@@ -1,14 +1,23 @@
 ---
 - name: Install lazy packages
-  dnf: name={{ item }} state=present
+  action: "{{ ansible_pkg_mgr }} name={{ item }} state=latest"
   with_items:
       - squid
       - httpd
+      - python-pulp-streamer
 
-- name: Install Squid proxy configuration
+- name: Install squid proxy configuration
   copy: src=squid.conf dest=/etc/squid/squid.conf
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int > 6
+
+- name: Install squid-3.1 proxy configuration
+  copy: src=squid-3.1.conf dest=/etc/squid/squid.conf
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "6"
 
 - file: path=/var/spool/squid state=directory owner=squid group=squid mode=750
 
 - name: Start and enable Squid service
   service: name=squid state=started enabled=yes
+
+- name: Start and enable Pulp streamer service
+  service: name=pulp_streamer state=started enabled=yes

--- a/ansible/roles/pulp-certs/tasks/main.yml
+++ b/ansible/roles/pulp-certs/tasks/main.yml
@@ -1,39 +1,45 @@
 ---
-- name: Create Pulp Certificate Authority
+- name: Create CA to sign all certificates
   command: >
-    /usr/bin/openssl req -x509 -newkey rsa:2048 -keyout private/cakey.pem -nodes -days 3650 \
+    /usr/bin/openssl req -x509 -newkey rsa:2048 -keyout private/cakey.pem -nodes -days 3650
      -out cacert.pem -subj '/C=US/ST=North Carolina/L=Raleigh/O=Pulp/OU=Development/CN=PulpCA'
   args:
     chdir: /etc/pki/CA/
     creates: cacert.pem
 
 - name: Create CA index.txt
-  command: /usr/bin/touch /etc/pki/CA/index.txt creates=/etc/pki/CA/index.txt
+  file: path=/etc/pki/CA/index.txt state=touch owner=root group=root mode=0644
+
+- name: Enable dynamic CA trust store
+  shell: update-ca-trust enable
+  when: ansible_distribution == "RedHat" and ansible_distribution_major_version|int == 6
 
 - name: Add CA to trust store
   shell: >
-    /usr/bin/cp /etc/pki/CA/cacert.pem /etc/pki/ca-trust/source/anchors/cacert.pem && \
-    /usr/bin/update-ca-trust
+    cp /etc/pki/CA/cacert.pem /etc/pki/ca-trust/source/anchors/cacert.pem
   args:
     creates: /etc/pki/ca-trust/source/anchors/cacert.pem
+
+- name: Update CA trust
+  shell: update-ca-trust
 
 - name: Configure openssl subjectAltName
   lineinfile: dest=/etc/pki/tls/openssl.cnf
               insertafter="^\[ usr_cert \]"
-              line="subjectAltName=DNS:{{ansible_hostname}},DNS:{{ansible_fqdn}}"
+              line="subjectAltName=DNS:{{ ansible_fqdn }},DNS:{{ ansible_nodename }},DNS:{{ ansible_hostname }}"
 
 - name: Create Apache certificate request
   command: >
-    /usr/bin/openssl req -newkey rsa:2048 -keyout private/apachekey.pem -nodes -days 365 \
+    /usr/bin/openssl req -newkey rsa:2048 -keyout private/apachekey.pem -nodes -days 365
     -out certs/apachereq.pem \
-    -subj '/C=US/ST=North Carolina/L=Raleigh/O=Pulp/OU=Development/CN={{ansible_hostname}}'
+    -subj '/C=US/ST=North Carolina/L=Raleigh/O=Pulp/OU=Development/CN={{ ansible_hostname }}'
   args:
     chdir: /etc/pki/tls/
     creates: certs/apachereq.pem
 
 - name: Sign Apache certificate
   command: >
-    /usr/bin/openssl ca -create_serial -in /etc/pki/tls/certs/apachereq.pem \
+    /usr/bin/openssl ca -create_serial -in /etc/pki/tls/certs/apachereq.pem
     -out /etc/pki/tls/certs/apachecert.pem -days 365 -keyfile /etc/pki/CA/private/cakey.pem -batch
   args:
     chdir: /etc/pki/tls/
@@ -53,4 +59,3 @@
       dest: /etc/httpd/conf.d/ssl.conf
       regexp: "^SSLCertificateKeyFile "
       line: "SSLCertificateKeyFile /etc/pki/tls/private/apachekey.pem"
-

--- a/ansible/roles/pulp-coverage/defaults/main.yaml
+++ b/ansible/roles/pulp-coverage/defaults/main.yaml
@@ -1,0 +1,26 @@
+# Define what action to perform
+#
+# Possible values are:
+#  * install: to install the coverage hook
+#  * report: to generate the coverage report
+#  * uninstall: to uninstall the coverage hook
+pulp_coverage_action: "install"
+
+# Directory where the coverage report is going to be created
+pulp_coverage_report_dir: "."
+
+# Enable to also generate HTML report
+pulp_coverage_report_html: false
+
+# Enable to also generate XML report
+pulp_coverage_report_xml: false
+
+# Enable to erase coverage source files after generating report
+pulp_coverage_report_erase: false
+
+# Services that need to be managed in order to coverage work
+pulp_coverage_services:
+  - httpd
+  - pulp_workers
+  - pulp_celerybeat
+  - pulp_resource_manager

--- a/ansible/roles/pulp-coverage/tasks/install.yaml
+++ b/ansible/roles/pulp-coverage/tasks/install.yaml
@@ -1,0 +1,40 @@
+---
+- name: Stop services
+  service:
+    name: "{{ item }}"
+    state: stopped
+  with_items: "{{ pulp_coverage_services }}"
+
+- name: Clean up previous coverage data
+  file:
+    path: /srv/pulp_coverage
+    state: absent
+
+- name: Create Pulp coverage directory
+  file:
+    mode: 01777
+    path: /srv/pulp_coverage
+    state: directory
+
+- name: Clone coverage repository
+  git:
+    repo: https://github.com/pulp/pulp.git
+    dest: pulp
+    depth: 1
+
+- name: Install pip package
+  action: "{{ ansible_pkg_mgr }} name=python-pip state=latest"
+
+- name: Install coverage package
+  command: pip install -U coverage
+
+- name: Install the coverage hook
+  command: ./coverage_hook install
+  args:
+    chdir: pulp/playpen/coverage
+
+- name: Start services
+  service:
+    name: "{{ item }}"
+    state: started
+  with_items: "{{ pulp_coverage_services }}"

--- a/ansible/roles/pulp-coverage/tasks/main.yaml
+++ b/ansible/roles/pulp-coverage/tasks/main.yaml
@@ -1,0 +1,9 @@
+---
+- include: install.yaml
+  when: pulp_coverage_action == "install"
+
+- include: report.yaml
+  when: pulp_coverage_action == "report"
+
+- include: uninstall.yaml
+  when: pulp_coverage_action == "uninstall"

--- a/ansible/roles/pulp-coverage/tasks/report.yaml
+++ b/ansible/roles/pulp-coverage/tasks/report.yaml
@@ -1,0 +1,22 @@
+---
+- name: Stop services
+  service:
+    name: "{{ item }}"
+    state: stopped
+  with_items: "{{ pulp_coverage_services }}"
+
+- name: Generate the coverage report
+  command: >
+      ./coverage_hook report
+      {% if pulp_coverage_report_erase|bool %}--erase{% endif %}
+      {% if pulp_coverage_report_html|bool %}--html{% endif %}
+      {% if pulp_coverage_report_xml|bool %}--xml{% endif %}
+      {{ pulp_coverage_report_dir }}
+  args:
+    chdir: pulp/playpen/coverage
+
+- name: Start services
+  service:
+    name: "{{ item }}"
+    state: started
+  with_items: "{{ pulp_coverage_services }}"

--- a/ansible/roles/pulp-coverage/tasks/uninstall.yaml
+++ b/ansible/roles/pulp-coverage/tasks/uninstall.yaml
@@ -1,0 +1,16 @@
+---
+- name: Uninstall the coverage hook
+  command: ./coverage_hook uninstall
+  args:
+    chdir: pulp/playpen/coverage
+
+- name: Remove coverage directory
+  file:
+    path: /srv/pulp_coverage
+    state: absent
+
+- name: Restart services
+  service:
+    name: "{{ item }}"
+    state: restarted
+  with_items: "{{ pulp_coverage_services }}"

--- a/ansible/roles/pulp-smash/defaults/main.yml
+++ b/ansible/roles/pulp-smash/defaults/main.yml
@@ -1,0 +1,11 @@
+# Pulp Server base URL
+pulp_smash_baseurl: "https://localhost"
+
+# Pulp Server username
+pulp_smash_username: "admin"
+
+# Pulp Server password
+pulp_smash_password: "admin"
+
+# If SSL certificate should be verified
+pulp_smash_verify: "false"

--- a/ansible/roles/pulp-smash/tasks/main.yaml
+++ b/ansible/roles/pulp-smash/tasks/main.yaml
@@ -1,0 +1,30 @@
+---
+
+- name: Remove previous Pulp Smash repository
+  shell: rm -rf pulp-smash
+
+- name: Clone Pulp Smash repository
+  git: repo=https://github.com/PulpQE/pulp-smash.git depth=1 dest=pulp-smash
+
+- name: Install required OS packages
+  action: "{{ ansible_pkg_mgr }} name={{ item }} state=present"
+  with_items:
+    - python
+    - python-pip
+    - python-virtualenv
+
+- name: Create Pulp Smash virtual environment
+  shell: virtualenv venv chdir=pulp-smash
+
+# mock Pulp Smash requirement requires an updated setuptools
+- name: Update setuptools
+  shell: venv/bin/pip install -U setuptools chdir=pulp-smash
+
+- name: Install Pulp Smash requirements
+  shell: venv/bin/pip install -r requirements.txt pytest chdir=pulp-smash
+
+- name: Configure Pulp Smash
+  template: src=settings.j2 dest=pulp-smash/pulp_smash/settings.json
+
+- name: Run Pulp Smash
+  shell: XDG_CONFIG_DIRS=. venv/bin/py.test --junit-xml=report.xml pulp_smash/tests chdir=pulp-smash

--- a/ansible/roles/pulp-smash/templates/settings.j2
+++ b/ansible/roles/pulp-smash/templates/settings.j2
@@ -1,0 +1,13 @@
+{
+    "pulp": {
+        "base_url": "{{ pulp_smash_baseurl }}",
+        "auth": ["{{ pulp_smash_username }}", "{{ pulp_smash_password }}"],
+        {% if pulp_smash_version %}
+        "version": "{{ pulp_smash_version }}",
+        {% endif %}
+        {% if pulp_smash_cli_transport %}
+        "cli_transport": "{{ pulp_smash_cli_transport }}",
+        {% endif %}
+        "verify": {{ pulp_smash_verify }}
+    }
+}

--- a/ansible/roles/pulp/defaults/main.yaml
+++ b/ansible/roles/pulp/defaults/main.yaml
@@ -1,0 +1,13 @@
+---
+
+# Whether to install recommended prerequisites
+pulp_install_prerequisites: true
+
+# Whether to install Pulp server
+pulp_install_server: true
+
+# Pulp version to install
+pulp_version: 2.9
+
+# Pulp build to install, the choices are: beta, nightly and stable
+pulp_build: nightly

--- a/ansible/roles/pulp/handlers/main.yaml
+++ b/ansible/roles/pulp/handlers/main.yaml
@@ -1,0 +1,26 @@
+---
+
+- name: Restart Apache service
+  service:
+    name: httpd
+    state: restarted
+
+- name: Restart Pulp workers service
+  service:
+    name: pulp_workers
+    state: restarted
+
+- name: Restart Pulp celerybeat service
+  service:
+    name: pulp_celerybeat
+    state: restarted
+
+- name: Restart Pulp resource manager service
+  service:
+    name: pulp_resource_manager
+    state: restarted
+
+- name: Restart goferd service
+  service:
+    name: goferd
+    state: restarted

--- a/ansible/roles/pulp/tasks/main.yaml
+++ b/ansible/roles/pulp/tasks/main.yaml
@@ -1,0 +1,61 @@
+---
+
+- name: Ensure expected distribution
+  assert:
+    that: ansible_os_family == "RedHat"
+
+- name: Open firewall ports
+  shell: "iptables -I INPUT -m state --state NEW -p tcp --dport {{ item }} -j ACCEPT"
+  with_items:
+    - 80
+    - 443
+    - 5672
+    - 5671
+  when: pulp_install_prerequisites
+
+- name: Subscription Manager register
+  shell: "subscription-manager register --force --user={{ rhn_username }} --password={{ rhn_password }}"
+  when: >
+      ansible_distribution == "RedHat" and rhn_username is defined and
+      rhn_password is defined and rhn_activation_key is undefined and
+      rhn_organization is undefined
+
+- name: Subscription Manager register by Activation Key
+  shell: >
+        subscription-manager register --force
+        --activationkey={{ rhn_activation_key }}
+        --org={{ rhn_organization }}
+  when: >
+      ansible_distribution == "RedHat" and rhn_activation_key is defined and
+      rhn_organization is defined
+
+- name: Subscription Manager subscribe
+  shell: "subscription-manager subscribe --pool={{ rhn_poolid }}"
+  when: ansible_distribution == "RedHat" and rhn_poolid is defined
+
+- name: Subscription Manager disable all repositories
+  shell: "subscription-manager repos --disable \"*\""
+  when: ansible_distribution == "RedHat"
+
+- name: Enable main repository
+  shell: "subscription-manager repos --enable rhel-{{ ansible_distribution_major_version }}-server-rpms"
+  when: ansible_distribution == "RedHat"
+
+- name: Enable optional repository
+  shell: "subscription-manager repos --enable rhel-{{ ansible_distribution_major_version }}-server-optional-rpms"
+  when: ansible_distribution == "RedHat"
+
+- name: Enable extras repository
+  shell: "subscription-manager repos --enable rhel-{{ ansible_distribution_major_version }}-server-extras-rpms"
+  when: ansible_distribution == "RedHat" and ansible_distribution_major_version|int >= 7
+
+- name: Enable atomic host repository
+  shell: "subscription-manager repos --enable rhel-atomic-host-rpms"
+  when: ansible_distribution == "RedHat" and ansible_distribution_major_version|int >= 7
+
+- name: Enable EPEL repository
+  action: "{{ ansible_pkg_mgr }} name=https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
+  when: ansible_distribution == "RedHat"
+
+- include: pulp_server.yaml
+  when: pulp_install_server

--- a/ansible/roles/pulp/tasks/pulp_server.yaml
+++ b/ansible/roles/pulp/tasks/pulp_server.yaml
@@ -1,0 +1,113 @@
+---
+- name: Install MongoDB server
+  action: "{{ ansible_pkg_mgr }} name={{ item }} state=latest"
+  with_items:
+    - mongodb-server
+    - mongodb
+
+- name: Start and enable MongoDB server service
+  service: name=mongod state=started enabled=yes
+
+- name: Setup qpid custom repo
+  get_url: url=https://copr.fedorainfracloud.org/coprs/g/qpid/qpid/repo/epel-6/irina-qpid-epel-6.repo dest=/etc/yum.repos.d/copr-qpid.repo
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 6
+
+- name: Install qpid-cpp server
+  action: "{{ ansible_pkg_mgr }} name={{ item }} state=latest"
+  with_items:
+    - qpid-cpp-server
+    - qpid-cpp-server-linearstore
+
+- name: Start and enable qpid-cpp server service
+  service: name=qpidd state=started enabled=yes
+
+- name: Setup Pulp nightly repository
+  template:
+    src: yum_repo.j2
+    dest: /etc/yum.repos.d/{{ item.key }}.repo
+  with_dict:
+    pulp:
+      name: Pulp Project repository
+      baseurl: "https://repos.fedorapeople.org/pulp/pulp/testing/automation/{{ pulp_version }}/stage/{% if ansible_distribution == 'Fedora' %}fedora-{% endif %}$releasever/$basearch/"
+
+      gpgcheck: 0
+  when: pulp_build == "nightly"
+
+- name: Setup Pulp beta or stable repository
+  template:
+    src: yum_repo.j2
+    dest: /etc/yum.repos.d/{{ item.key }}.repo
+  with_dict:
+    pulp:
+      name: Pulp Project repository
+      baseurl: "https://repos.fedorapeople.org/pulp/pulp/{{ pulp_build }}/{{ pulp_version }}/{% if ansible_distribution == 'Fedora' %}fedora-{% endif %}$releasever/$basearch/"
+      gpgcheck: 0
+  when: pulp_build == "beta" or pulp_build == "stable"
+
+- name: Install Pulp Server
+  action: "{{ ansible_pkg_mgr }} name=@pulp-server-qpid"
+  notify:
+    - Restart Apache service
+    - Restart Pulp workers service
+    - Restart Pulp celerybeat service
+    - Restart Pulp resource manager service
+
+- name: Install Pulp Admin (RPM, Puppet, Docker)
+  action: "{{ ansible_pkg_mgr }} name=@pulp-admin"
+
+- name: Install OSTree
+  action: "{{ ansible_pkg_mgr }} name={{ item }} state=latest"
+  with_items:
+    - pulp-ostree-plugins
+    - pulp-ostree-admin-extensions
+  when: (ansible_distribution == "RedHat" and ansible_distribution_major_version|int >= 7) or
+        (ansible_distribution == "Fedora" and ansible_distribution_major_version|int >= 23)
+
+- name: Install Pulp Python plugin
+  action: "{{ ansible_pkg_mgr }} name={{ item }} state=latest"
+  with_items:
+    - pulp-python-plugins
+    - pulp-python-admin-extensions
+  notify:
+    - Restart Apache service
+
+- name: Configure pulp-admin
+  shell: "sudo sed -i 's/# verify_ssl: True/verify_ssl: False/g' /etc/pulp/admin/admin.conf"
+
+- name: Check if Pulp's DB was initialized
+  stat:
+    path: /var/lib/pulp/db_initialized.flag
+  register: db_init
+
+- name: Initialize Pulp's DB
+  shell: sudo -u apache pulp-manage-db && touch /var/lib/pulp/db_initialized.flag
+  notify:
+    - Restart Apache service
+    - Restart Pulp workers service
+    - Restart Pulp celerybeat service
+    - Restart Pulp resource manager service
+  when: not db_init.stat.exists
+
+- name: Ensure Apache server is running
+  service:
+    name: httpd
+    enabled: yes
+    state: running
+
+- name: Ensure Pulp workers are running
+  service:
+    name: pulp_workers
+    enabled: yes
+    state: running
+
+- name: Ensure Pulp celerybeat is running
+  service:
+    name: pulp_celerybeat
+    enabled: yes
+    state: running
+
+- name: Ensure Pulp resource manager is running
+  service:
+    name: pulp_resource_manager
+    enabled: yes
+    state: running

--- a/ansible/roles/pulp/templates/yum_repo.j2
+++ b/ansible/roles/pulp/templates/yum_repo.j2
@@ -1,0 +1,4 @@
+[{{ item.key }}]
+{% for key, value in item.value.iteritems() | sort -%}
+  {{ key }}={{ value }}
+{% endfor %}

--- a/ansible/vagrant-playbook.yml
+++ b/ansible/vagrant-playbook.yml
@@ -15,4 +15,4 @@
     - qpidd
     - dev
     - lazy
-    - pulp_ca
+    - pulp-certs


### PR DESCRIPTION
I went with the pulp_packaging version of the ``lazy`` and ``pulp-certs`` roles, which are more general. I didn't attempt to de-duplicate anything beyond those overlapping roles, but this will at least have us all working in the same repository for Ansible.