### PR TITLE
Ansible now looks for the pulp/packaging repo for specs

### DIFF
--- a/ansible/roles/core/tasks/main.yml
+++ b/ansible/roles/core/tasks/main.yml
@@ -13,6 +13,7 @@
 - name: Install packages requires to gather Pulp facts
   dnf: name={{ item }} state=present
   with_items:
+      - git
       - rpm-build
 
 - name: Gathering Pulp facts


### PR DESCRIPTION
In 3.0-dev branches, the spec files have been removed from the project
repositories. Ansible needs to look in the packaging repository to
gather the list of dependencies.