### PR TITLE
ansible: fix pulp_facts when selinux-policy not installed

### DIFF
--- a/ansible/roles/core/tasks/main.yml
+++ b/ansible/roles/core/tasks/main.yml
@@ -14,6 +14,7 @@
   dnf: name={{ item }} state=present
   with_items:
       - rpm-build
+      - selinux-policy
 
 - name: Gathering Pulp facts
   pulp_facts:


### PR DESCRIPTION
If selinux-policy package is not installed, rpmspec produces spurious
requirements for packages named "selinux-policy", "is", "not", "installed"
which breaks subsequent ansible tasks.  This is due to the macro in
pulp.spec:

  %define selinux_policyver %(rpm --qf "%%{version}-%%{release}" -q %%selinux-policy)

We know we'll need this package anyway, so just install it a bit
earlier to fix this.