### PR TITLE
Updates bashrc for new worker layout

### DIFF
--- a/ansible/roles/dev/files/bashrc
+++ b/ansible/roles/dev/files/bashrc
@@ -142,9 +142,9 @@ pprocs() {
 
     # override IFS to prevent bash splitting pgrep output on newlines
     IFS=''
-    print_procs "Pulp worker processes" `pgrep -f "pulp.server.async.app -c 1"`
-    print_procs "Pulp Resource Manager processes" `pgrep -f "pulp.server.async.app -n resource_manager"`
-    print_procs "Pulp Celerybeat processes:" `pgrep -f "pulp.server.async.celery_instance.celery"`
+    print_procs "Pulp worker processes" `pgrep -f "pulp.tasking.celery_app -c 1"`
+    print_procs "Pulp Resource Manager processes" `pgrep -f "pulp.tasking.celery_app -n resource_manager"`
+    print_procs "Pulp Celerybeat processes:" `pgrep -f "pulp.tasking.celery_instance.celery"`
     print_procs "Pulp WSGI processes:" `pgrep -f "wsgi:pulp"`
     unset IFS
 }


### PR DESCRIPTION
The worker python modules are moved into pulp.tasking now.