### PR TITLE
Starts pulp_streamer with other pulp services

### DIFF
--- a/ansible/roles/lazy/tasks/main.yml
+++ b/ansible/roles/lazy/tasks/main.yml
@@ -20,4 +20,4 @@
   service: name=squid state=started enabled=yes
 
 - name: Start and enable Pulp streamer service
-  service: name=pulp_streamer state=started enabled=yes
+  service: name=pulp_streamer enabled=yes


### PR DESCRIPTION
This is so plugins are loaded into the streamer.

closes #2272
https://pulp.plan.io/issues/2272