### PR TITLE
Restart services on vagrant-setup

### DIFF
--- a/ansible/roles/lazy/tasks/main.yml
+++ b/ansible/roles/lazy/tasks/main.yml
@@ -20,4 +20,4 @@
   service: name=squid state=started enabled=yes
 
 - name: Start and enable Pulp streamer service
-  service: name=pulp_streamer enabled=yes
+  service: name=pulp_streamer state=started enabled=yes

--- a/scripts/vagrant-setup.sh
+++ b/scripts/vagrant-setup.sh
@@ -90,7 +90,7 @@ done
 
 sudo -u apache pulp-manage-db;
 setup_crane_links;
-pstart;
+prestart;
 ppopulate;
 
 # Give the user some use instructions


### PR DESCRIPTION
Services are already started by ansible, it make sense to do a prestart instead of a pstart on vagrant setup.