### PR TITLE
Adds a kombu developer playbook

### DIFF
--- a/ansible/kombu-playbook.yml
+++ b/ansible/kombu-playbook.yml
@@ -1,0 +1,5 @@
+---
+- hosts: dev
+  vars:
+  roles:
+    - kombu

--- a/ansible/roles/kombu/tasks/main.yaml
+++ b/ansible/roles/kombu/tasks/main.yaml
@@ -1,0 +1,25 @@
+---
+
+- name: Remove the python-kombu rpm
+  command: rpm -e --nodeps python-kombu
+  become: true
+  become_method: sudo
+  register: command_result
+  failed_when: "'python-kombu is not installed' not in command_result.stderr"
+
+- name: Check that ~/devel/kombu is a directory
+  stat: path=~/devel/kombu/
+  register: kombu_stat
+
+- assert:
+    that:
+      - kombu_stat.stat.isdir is defined
+      - kombu_stat.stat.isdir
+    msg: "You have to clone kombu at ~/devel/kombu"
+
+- name: Install kombu with a developer checkout
+  command: python setup.py develop
+  args:
+    chdir: /home/vagrant/devel/kombu/
+  become: true
+  become_method: sudo


### PR DESCRIPTION
I hack on kombu in the Vagrant environment, but the
default install is rpm based.

This little playbook converts the kombu installation
to a developer checkout in ~/devel/kombu