### PR TITLE
Problem: upstream Pulp repositories not enabled on Vagrant box

### DIFF
--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -12,7 +12,7 @@
   notify: restart sshd
 
 - name: Install Pulp dnf repository
-  when: ansible_distribution == 'Fedora' and ansible_distribution_version|int < 24
+  when: ansible_distribution == 'Fedora'
   get_url:
       url: https://repos.fedorapeople.org/repos/pulp/pulp/fedora-pulp.repo
       dest: /etc/yum.repos.d/fedora-pulp.repo
@@ -22,7 +22,7 @@
 
 - name: Enable Pulp Nightly repository
   command: dnf config-manager --set-enabled pulp-nightlies
-  when: ansible_distribution == 'Fedora' and ansible_distribution_version|int < 24 and pulp_nightly_repo_enabled == false
+  when: ansible_distribution == 'Fedora' and pulp_nightly_repo_enabled == false
 
 # These can go away when https://fedorahosted.org/spin-kickstarts/ticket/59 is fixed
 - stat:


### PR DESCRIPTION
Solution: Stop checking version of Fedora running on the dev machine when
deciding whether or not to enable the upstream repositories

closes #2489
https://pulp.plan.io/issues/2489