### PR TITLE
Problem: gofer package not installed on Vagrant box

### DIFF
--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -69,6 +69,11 @@
       - yum-utils
       - zlib-devel
 
+- name: Install gofer
+  dnf: name={{ item }} state=present
+  with_items:
+      - gofer
+
 - name: allow vagrant user to read the systemd journal
   user:
       name: vagrant


### PR DESCRIPTION
Solution: expand the dev role to install gofer package

closes #2465
https://pulp.plan.io/issues/2465