### PR TITLE
Ignore the user-specific Vagrantfile and .vagrant directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,10 @@ celerybeat-schedule
 venv/
 ENV/
 
+# Vagrant environment
+.vagrant
+Vagrantfile
+
 # Spyder project settings
 .spyderproject
 


### PR DESCRIPTION
To help avoid people accidentally including their personal vagrant setup in a commit