### PR TITLE
Checkout script uses master by default

### DIFF
--- a/scripts/checkout.py
+++ b/scripts/checkout.py
@@ -21,7 +21,7 @@ BASE_DIR_TEMPLATE = '~/devel/%s'
 
 def get_args():
     parser = argparse.ArgumentParser(description='Checkout your repos to a version of Pulp')
-    parser.add_argument('--version', required=True, help='the version of Pulp to check out')
+    parser.add_argument('--version', default='master', help='the version of Pulp to check out')
     parser.add_argument('--remote', default='pulp', help='the name of the pulp remote to fetch from')
     return  parser.parse_args()
 


### PR DESCRIPTION
Previously the checkout script required 'version' to be set.
This change sets 'master' as the default value for 'version'.
Running the following will now check out master.

    python scripts/checkout.py