### PR TITLE
Vagrant: bump Fedora version when using docker

### DIFF
--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -94,7 +94,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         override.vm.box = nil
         # Based on fedora official image, with vagrant's needs met:
         # https://github.com/rohanpm/docker-fedora-vagrant
-        d.image = 'rohanpm/fedora-vagrant:23'
+        d.image = 'rohanpm/fedora-vagrant:24'
 
         # use ssh for the sake of ansible
         d.has_ssh = true


### PR DESCRIPTION
Bring the major Fedora version used for docker in-line with the version
used with libvirt.  Both vagrant providers should be using the same base.