### PR TITLE
Update Vagrant example to f25

### DIFF
--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -26,8 +26,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
  # Sometimes, a nightly compose is incomplete and does not contain a Vagrant image, so you may need
  # to browse that repository a bit to find the latest successful Vagrant image. For example, at the
  # time of this writing, I could set this setting like this for the latest F24 image:
- # config.vm.box = "https://kojipkgs.fedoraproject.org/compose/24/Fedora-24-20160430.0/compose/CloudImages/x86_64/images/Fedora-Cloud-Base-Vagrant-24_Beta-1.4.x86_64.vagrant-libvirt.box"
- config.vm.box = "fedora/24-cloud-base"
+ # config.vm.box = "https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/CloudImages/x86_64/images/<imagename>.vagrant-libvirt.box"
+ config.vm.box = "fedora/25-cloud-base"
 
  # Comment out if you don't want Vagrant to add and remove entries from /etc/hosts for each VM.
  # requires the vagrant-hostmanager plugin to be installed


### PR DESCRIPTION
Tested this just now. We've already made this change on 3.0-dev, but we (really, I...) didn't bring that change to master, which is still on fedora 24. I just vagrant up'd with this and ran all tests, everything seems fine (which, again, was our experience on 3.0-dev).

Thanks to @rohanpm for pointing out this oversight in #29.