### PR TITLE
Vagrant stops installing pulp-server rpm

### DIFF
--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -24,6 +24,10 @@
   command: dnf config-manager --set-enabled pulp-nightlies
   when: ansible_distribution == 'Fedora' and pulp_nightly_repo_enabled == false
 
+- name: Disable Pulp Stable repository
+  command: dnf config-manager --set-disabled pulp-2-stable
+  when: ansible_distribution == 'Fedora'
+
 # These can go away when https://fedorahosted.org/spin-kickstarts/ticket/59 is fixed
 - stat:
       path: /etc/sudoers.d/vagrant-nopasswd

--- a/ansible/roles/lazy/tasks/main.yml
+++ b/ansible/roles/lazy/tasks/main.yml
@@ -4,7 +4,6 @@
   with_items:
       - squid
       - httpd
-      - python-pulp-streamer
 
 - name: Install squid proxy configuration
   copy: src=squid.conf dest=/etc/squid/squid.conf
@@ -18,6 +17,3 @@
 
 - name: Start and enable Squid service
   service: name=squid state=started enabled=yes
-
-- name: Start and enable Pulp streamer service
-  service: name=pulp_streamer state=started enabled=yes


### PR DESCRIPTION
This fix requires https://github.com/pulp/pulp/pull/2959 to be merged first

closes #2497
https://pulp.plan.io/issues/2497