### PR TITLE
Provisioning updates for Pulp 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,7 +93,7 @@ rel-eng/*
 !rel-eng/config
 
 # Vagrant
-Vagrantfile
+Vagrantfile*
 .vagrant
 .dnf-cache
-ansible/dev-playbook.retry
+ansible/*.retry

--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -21,50 +21,57 @@ VAGRANT_SYNCED_FOLDERS = {
 }
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
- # It is possible to use URLs to nightly images produced by the Fedora project here. You can find
- # the nightly composes here: https://kojipkgs.fedoraproject.org/compose/
- # Sometimes, a nightly compose is incomplete and does not contain a Vagrant image, so you may need
- # to browse that repository a bit to find the latest successful Vagrant image. For example, at the
- # time of this writing, I could set this setting like this for the latest F24 image:
- # config.vm.box = "https://kojipkgs.fedoraproject.org/compose/24/Fedora-24-20160430.0/compose/CloudImages/x86_64/images/Fedora-Cloud-Base-Vagrant-24_Beta-1.4.x86_64.vagrant-libvirt.box"
- config.vm.box = "fedora/25-cloud-base"
+  # It is possible to use URLs to nightly images produced by the Fedora project here. You can find
+  # the nightly composes here: https://kojipkgs.fedoraproject.org/compose/
+  # Sometimes, a nightly compose is incomplete and does not contain a Vagrant image, so you may need
+  # to browse that repository a bit to find the latest successful Vagrant image. For example, at the
+  # time of this writing, I could set this setting like this for the latest F24 image:
+  # config.vm.box = "https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/CloudImages/x86_64/images/<imagename>.vagrant-libvirt.box"
+  config.vm.box = "fedora/25-cloud-base"
 
- # Comment out if you don't want Vagrant to add and remove entries from /etc/hosts for each VM.
- # requires the vagrant-hostmanager plugin to be installed
- if Vagrant.has_plugin?("vagrant-hostmanager")
-     config.hostmanager.enabled = true
-     config.hostmanager.manage_host = true
- end
+  # Comment out if you don't want Vagrant to add and remove entries from /etc/hosts for each VM.
+  # requires the vagrant-hostmanager plugin to be installed
+  if Vagrant.has_plugin?("vagrant-hostmanager")
+      config.hostmanager.enabled = true
+      config.hostmanager.manage_host = true
+  end
 
- # provision with ansible
- config.vm.provision "ansible" do |ansible|
-     ansible.playbook = "ansible/dev-playbook.yml"
-     ansible.extra_vars = {
-        # Uncomment this if you want debug tools like gdb, tcpdump, et al. installed
-        # (you probably don't, unless you know you do)
-        # use_debug_role: true,
-        # This role is required when provisioning in vagrant
-        use_vagrant_role: true,
-        # The dev playbook does not work without python3
-        ansible_python_interpreter: '/usr/bin/python3'
-     }
- end
+  # provision with ansible
+  config.vm.provision "ansible" do |ansible|
+      ansible.playbook = "ansible/dev-playbook.yml"
+      ansible.extra_vars = {
+         # Uncomment this if you want debug tools like gdb, tcpdump, et al. installed
+         # (you probably don't, unless you know you do)
+         # use_debug_role: true,
+         # This role is required when provisioning in vagrant
+         use_vagrant_role: true,
+         # The dev playbook does not work without python3
+         ansible_python_interpreter: '/usr/bin/python3'
+      }
+  end
 
- # Create the "dev" box
- config.vm.define "dev" do |dev|
+  # Create the "dev" box
+  config.vm.define "dev" do |dev|
     dev.vm.host_name = "dev.example.com"
 
     VAGRANT_SYNCED_FOLDERS.each do |host_path, guest_path|
+        # Use SSHFS instead of NFS. Requires the vagrant-sshfs plugin to be installed.
         # Use SSHFS to share directories. The ``-o nonempty`` option is passed to allow
         # mounts on non-empty directories.
-        dev.vm.synced_folder host_path, guest_path, type: "sshfs", sshfs_opts_append: "-o nonempty"
+        # dev.vm.synced_folder host_path, guest_path, type: "sshfs", sshfs_opts_append: "-o nonempty"
 
-        # If you would prefer to use NFSv4, you can uncomment the line below
-        # dev.vm.synced_folder host_path, guest_path, type: "nfs", nfs_version: 4, nfs_udp: false
+        # Comment this out if you use a different filesystem (like sshfs)
+        dev.vm.synced_folder host_path, guest_path, type: "nfs", nfs_version: 4, nfs_udp: false
     end
 
     dev.vm.provider :libvirt do |domain, override|
         domain.cpus = 4
+        # In some cases, the guest gets stuck at "Waiting for domain to get an IP address..." if
+        # the default cpu_mode, 'host-model', is used. Using 'host-passthrough' cpu_mode prevents
+        # VM migration between hosts with different CPUs. However, development environments are
+        # expected to live on a single host for the duration of their existence. Due to this known
+        # issue and our use case, the default cpu_mode is overridden.
+        domain.cpu_mode = "host-passthrough"
         domain.graphics_type = "spice"
         domain.memory = 2048
         domain.video_type = "qxl"
@@ -93,7 +100,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         override.vm.box = nil
         # Based on fedora official image, with vagrant's needs met:
         # https://github.com/rohanpm/docker-fedora-vagrant
-        d.image = 'rohanpm/fedora-vagrant:23'
+        d.image = 'rohanpm/fedora-vagrant:25'
 
         # use ssh for the sake of ansible
         d.has_ssh = true

--- a/ansible/library/pulp_facts.py
+++ b/ansible/library/pulp_facts.py
@@ -47,8 +47,10 @@ repositories = [
 ] + plugins
 
 # lists of requirements files to be installed into virtualenvs, when those virtualenvs exist
+# all requirements found in a given repository matching these filenames will be installed into
+# the corresponding virtualenvs using code from that repository
 requirements_files = {
-    'pulp': ['test_requirements.txt'],
+    'pulp': ['test_requirements.txt', 'dev_requirements.txt'],
     'crane': ['test-requirements.txt'],
     'pulp-smash': ['requirements.txt', 'requirements-dev.txt'],
 }


### PR DESCRIPTION
- Example Vagrantfile updated with changes from pulp 2
- modified the gitignore to ignore different Vagrantfiles and
  all playbook retry files from ansible.
- Playbook updated to use the dev_requirements file intoduced in
  https://github.com/pulp/pulp/pull/2888