### PR TITLE
Platform virtualenv installs pulp_file

### DIFF
--- a/ansible/library/pulp_facts.py
+++ b/ansible/library/pulp_facts.py
@@ -27,11 +27,12 @@ rpm_projects = [
 
 # plugin repository names, declared deparately from all repositories for easy filtering later
 plugins = [
-    'pulp_puppet',
-    'pulp_rpm',
     'pulp_docker',
+    'pulp_file',
     'pulp_ostree',
+    'pulp_puppet',
     'pulp_python',
+    'pulp_rpm',
 ]
 
 # all repository names, used first to make sure the platform repository is cloned in its configured

--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -137,6 +137,21 @@
       - exceptions
       - tasking
 
+# We don't currently have a common method for installing plugins for development. In Pulp 2, it was
+# "run pulp-dev.py -I", so maybe that's what we'll do for pulp 3 as well. For now, since only the
+# file plugin works with "python setup.py develop", we'll just try that
+# exists, installing plugins to the platform virtualenv
+- name: Install Plugin packages into Platform Virtualenv
+  command: "{{ pulp_venv_dir }}/pulp/bin/python setup.py develop"
+  args:
+    chdir: "{{ pulp_devel_dir }}/{{ item }}"
+  # If we stick with running setup.py develop for all plugins, we'd want to do it for all available
+  # plugins. For now, it only works with pulp_file
+  # with_items: "{{ pulp_available_plugins }}"
+  with_items:
+      - pulp_file
+  when: "{{ [item] | issubset(pulp_available_plugins) }}"
+
 - block:
   - name: Install crane config
     template:

--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -135,6 +135,7 @@
       - app
       - common
       - exceptions
+      - plugin
       - tasking
 
 # We don't currently have a common method for installing plugins for development. In Pulp 2, it was


### PR DESCRIPTION
I'm been digging into figuring out why the platform virtualenv appeared
to be getting set up improperly, and had started down a scary path of
redoing how those virtualenvs get created. Then Austin asked me if the
'- plugin' item was left out of the platform virtualenv setup on
purpose. I'd just noticed that too, and discovered that this was the
actual cause of the virtualenv problems and I'd just missed it. Woot.

I was able to steal some of the virtualenv work I was doing, though, and
make the playbook also install pulp_file into the platform virtualenv if
the repo's cloned into the devel dir when the playbook runs, so that's
cool too.