### PR TITLE
Install gcc-c++ in dev environment

### DIFF
--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -47,6 +47,7 @@
       - python-rpdb
       # Dependencies for building python packages with C components
       - gcc
+      - gcc-c++
       - postgresql-devel
       - python3-devel
       # Dependencies for building pulp RPMs


### PR DESCRIPTION
A pulp-smash dependency (editdistance) has recently changed, and now requires c++ support in gcc for its binary components to successfully install.