### PR TITLE
Reorder the kombu ansible playbook

### DIFF
--- a/ansible/roles/kombu/tasks/main.yaml
+++ b/ansible/roles/kombu/tasks/main.yaml
@@ -1,11 +1,5 @@
 ---
 
-- name: Remove the python-kombu rpm
-  command: rpm -e --nodeps python-kombu
-  become: true
-  become_method: sudo
-  ignore_errors: True
-
 - name: Check that ~/devel/kombu is a directory
   stat: path=~/devel/kombu/
   register: kombu_stat
@@ -15,6 +9,12 @@
       - kombu_stat.stat.isdir is defined
       - kombu_stat.stat.isdir
     msg: "You have to clone kombu at ~/devel/kombu"
+
+- name: Remove the python-kombu rpm
+  command: rpm -e --nodeps python-kombu
+  become: true
+  become_method: sudo
+  ignore_errors: True
 
 - name: Install kombu with a developer checkout
   command: python setup.py develop


### PR DESCRIPTION
Without this reordering if you run the playbook without having Kombu
cloned locally your Pulp installation will be broken. By reordering this
all of the checking happens up front which should allow your Pulp
environment to still be working regardless of if the playbook passes or
fails.