### PR TITLE
Fix replacing python-lxml if not on rpm_dependency_list

### DIFF
--- a/ansible/library/pulp_facts.py
+++ b/ansible/library/pulp_facts.py
@@ -52,8 +52,9 @@ rpm_dependency_list = list(set(rpm_dependency_list))
 
 # Replace python-lxml with python2-lxml
 # https://www.redhat.com/archives/pulp-dev/2016-December/msg00042.html
-rpm_dependency_list.remove('python-lxml')
-rpm_dependency_list.append('python2-lxml')
+if 'python-lxml' in rpm_dependency_list:
+    rpm_dependency_list.remove('python-lxml')
+    rpm_dependency_list.append('python2-lxml')
 
 # Build the facts for Ansible
 facts = {


### PR DESCRIPTION
Provisioning fails, if python-lxml is not in rpm_dependency_list.
This version replaces python-lxml silently and does nothing if it is not found.
If you dislike list comprehensions, i can provide another version.