### PR TITLE
fix ptest - Migrate auth because User depends on it

### DIFF
--- a/ansible/roles/vagrant/templates/bashrc.j2
+++ b/ansible/roles/vagrant/templates/bashrc.j2
@@ -89,6 +89,8 @@ ptest() {
     # manage.py test will create and migrate its own database,
     # but we still need to make the migrations for it to be able to do that.
     python manage.py makemigrations pulp_app
+    # Auth migrations must be run before platform to generates schema that the User model relates to.
+    python manage.py migrate auth --noinput
     python manage.py test platform/ common/
 }
 _ptest_help="Run tests for pulp and all installed plugins/services"


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.8/topics/migrations/#dependencies

Django can't create a test database without schema generation of auth. See this comment for more detail. https://github.com/pulp/pulp/blob/b86677f069c03643380d98bc51cd1291fdfa3289/platform/pulp/app/db-reset.sh#L18-L24