### PR TITLE
translate new pulp_deb dependencies, to pip dependencies

### DIFF
--- a/ansible/library/pulp_facts.py
+++ b/ansible/library/pulp_facts.py
@@ -50,11 +50,21 @@ for project in projects:
 # Remove any duplicates
 rpm_dependency_list = list(set(rpm_dependency_list))
 
+pip_dependency_list = list()
+
 # Replace python-lxml with python2-lxml
 # https://www.redhat.com/archives/pulp-dev/2016-December/msg00042.html
 if 'python-lxml' in rpm_dependency_list:
     rpm_dependency_list.remove('python-lxml')
     rpm_dependency_list.append('python2-lxml')
+
+if 'python-debian' in rpm_dependency_list:
+    rpm_dependency_list.remove('python-debian')
+    pip_dependency_list.append('python-debian')
+
+if 'python-debpkgr' in rpm_dependency_list:
+    rpm_dependency_list.remove('python-debpkgr')
+    pip_dependency_list.append('debpkgr')
 
 # Build the facts for Ansible
 facts = {
@@ -62,6 +72,7 @@ facts = {
         'pulp_nightly_repo_enabled': pulp_nightly_repo_enabled,
         'selinux_enabled': selinux_enabled,
         'pulp_rpm_dependencies': rpm_dependency_list,
+        'pulp_pip_dependencies': pip_dependency_list,
     }
 }
 

--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -96,6 +96,10 @@
   dnf: name={{ item }} state=present
   with_items: "{{ pulp_rpm_dependencies }}"
 
+- name: Install Pulp PIP dependencies
+  pip: name={{ item }} state=present executable=/usr/bin/pip
+  with_items: "{{ pulp_pip_dependencies }}"
+
 - name: Ensure homedir mode suitable for ssh keys
   file: dest=/home/{{ ansible_env.SUDO_USER }} mode=0750
 


### PR DESCRIPTION
This is a hack, to provide the debian specific python packages,
that are required by pulp_deb and not part of official repositories,
with pip.