### PR TITLE
Add netrc file to store admin credentials

### DIFF
--- a/ansible/roles/common/files/netrc
+++ b/ansible/roles/common/files/netrc
@@ -1,0 +1,3 @@
+machine localhost
+login admin
+password admin

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -58,3 +58,10 @@
     dest: "{{ unprivileged_homedir }}/.vimrc"
     force: no
   become: false
+
+- name: Add a basic .netrc file if not present
+  copy:
+    src: files/netrc
+    dest: "{{ unprivileged_homedir }}/.netrc"
+    force: no
+  become: false

--- a/ansible/roles/common/templates/alias.bashrc
+++ b/ansible/roles/common/templates/alias.bashrc
@@ -140,4 +140,4 @@ phelp() {
 }
 _phelp_help="Print this help"
 
-alias phttp="http --verify no --cert {{ unprivileged_homedir }}/.pulp/user-cert.pem"
+alias phttp="http"


### PR DESCRIPTION
This will allow us to make calls via httpie without having to supply credentials every time. More info:

https://github.com/jakubroztocil/httpie#netrc

Before:

```
http --auth admin:admin :3000/api/v3/repositories/
```

After:

```
http :3000/api/v3/repositories/
```

Note that you can still override credentials by setting `--auth`.