### PR TITLE
Adds base-dir option

### DIFF
--- a/scripts/checkout.py
+++ b/scripts/checkout.py
@@ -18,13 +18,13 @@ import yaml
 
 
 REPOS = ['crane', 'pulp', 'pulp_docker', 'pulp_ostree', 'pulp_puppet', 'pulp_python', 'pulp_rpm']
-BASE_DIR_TEMPLATE = '~/devel/%s'
 
 
 def get_args():
     parser = argparse.ArgumentParser(description='Checkout your repos to a version of Pulp')
     parser.add_argument('--version', default='master', help='the version of Pulp to check out')
     parser.add_argument('--remote', default='pulp', help='the name of the pulp remote to fetch from')
+    parser.add_argument('--base-dir', default='../', help='the directory that contains your pulp checkouts.')
     return parser.parse_args()
 
 
@@ -40,7 +40,7 @@ def get_yaml(args):
 
 def check_checkouts(args):
     for repo in REPOS:
-        checkout_path = os.path.expanduser(BASE_DIR_TEMPLATE % repo)
+        checkout_path = args.base_dir_template.format(repo)
         if os.path.exists(checkout_path):
             try:
                 subprocess.check_call(["git", "diff", "--exit-code"], cwd=checkout_path)
@@ -51,7 +51,7 @@ def check_checkouts(args):
 
 def fetch_and_checkout(args, yaml):
     for repo in REPOS:
-        checkout_path = os.path.expanduser(BASE_DIR_TEMPLATE % repo)
+        checkout_path = args.base_dir_template.format(repo)
         if os.path.exists(checkout_path):
             subprocess.check_call(["git", "fetch", args.remote], cwd=checkout_path)
             for entry in yaml['repositories']:
@@ -60,8 +60,19 @@ def fetch_and_checkout(args, yaml):
             subprocess.call(["find", "./", "-name", "*.py[c0]", "-delete"], cwd=checkout_path)
 
 
+def validate_and_add_path(args):
+    full_path = os.path.expanduser(args.base_dir)
+    if not os.path.isdir(full_path):
+        raise Exception("The directory {0} is not a valid directory".format(full_path))
+    if os.access(full_path, os.R_OK):
+        args.base_dir_template = full_path + '{0}'
+        return args
+    raise Exception("The directory {0} is not readable")
+
+
 def main():
     args = get_args()
+    args = validate_and_add_path(args)
     check_checkouts(args)
     yaml = get_yaml(args)
     fetch_and_checkout(args, yaml)


### PR DESCRIPTION
The base-dir option allows the checkout.py script to operate on a pulp
checkout anywhere on the filesystem.

(cherry picked from commit f024edc5f036834802006d74277e34f83c37db92)