### PR TITLE
Simplify variable usage

### DIFF
--- a/ansible/example-playbook.yml
+++ b/ansible/example-playbook.yml
@@ -3,7 +3,6 @@
   become: true
   become_method: sudo
   vars:
-    pip_install_extras: true
     supplement_bashrc: true
   roles:
     - vagrant

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -12,8 +12,6 @@ pulp_venv: "{{ venv_dir }}/pulp"
 # This is only required if you enable the smash role
 pulp_smash_venv: "{{ venv_dir }}/pulp-smash"
 
-# non-essential requirements files listed in pulp_facts.py will be pip installed
-pip_install_extras: false
 # If enabled, `phelp` and other useful aliases are sourced by your bashrc.
 # In adition, some roles will add other relevant bashrc supplements
 supplement_bashrc: false

--- a/ansible/roles/dev/defaults/main.yml
+++ b/ansible/roles/dev/defaults/main.yml
@@ -1,0 +1,2 @@
+# non-essential requirements files listed in pulp_facts.py will be pip installed
+pip_install_extras: true

--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -30,7 +30,7 @@
       - test_requirements.txt
       - dev_requirements.txt
       - docs/requirements.txt
-    when: pip_install_extras is defined and pip_install_extras
+    when: pip_install_extras
 
   - name: Install Pulp Platform packages
     pip:


### PR DESCRIPTION
The `pip_install_extras` variable is mentioned in three places:

1. It's used by the `dev` role. By default, the variable is undefined,
   so the reference to this variable must account for this with an `if
   pip_install_extras is defined ...`.
2. It's set to `false` for group "all."
3. It's set to `true` by `example-playbook.yml`. (Note that the playbook
   only applies to hosts in group "pulp3_dev.")

This is a bit complicated for a variable that's used exactly once.
Simplify things by giving this variable a default value.

This has the down-side of making this variable less obvious. However,
the proper fix is to document this variable in the site-wide readme or
`roles/dev/README.md`, instead of spamming the code base with this
variable. No formal documentation is added by this commit.

As a side note, this variable should be renamed, in order to prevent a
name conflict. Most variables continue to be visible for the entire
duration of a play. This means that variables created by the invocation
of one role are visible by following role invocations, `post_tasks`,
etc. A good rule of thumb is to prefix all variable names with the name
of their containing role.