### PR TITLE
Fix weakness in bash script

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -36,8 +36,8 @@
     path: "{{ unprivileged_homedir }}/.bashrc"
     block: |
       if [ -d ~/.bashrc.d ]; then
-        for file in $(/bin/ls ~/.bashrc.d/*.bashrc); do
-          . $file;
+        for file in ~/.bashrc.d/*.bashrc; do
+          . "$file"
         done
       fi
     create: yes


### PR DESCRIPTION
Bash processes input in a pipelined fashion. In order, several of the
steps are:

1. Variable expansion.
2. Command substitution.
3. Word splitting.
4. Globbing.

Therefore:

* Variables should be quoted.
* It is safe to perform globbing without worrying about word splitting.

The point about globbing may seem non-obvious. Here's an example:

```console
$ touch 'one two' three
$ ls -1
'one two'
three
$ for file in $(/bin/ls .); do echo "$file"; done
one
two
three
$ for file in ./*; do echo "$file"; done
./one two
./three
```