### PR TITLE
Rename playbook for installing Pulp from source

### DIFF
--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -38,7 +38,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provision "ansible" do |ansible|
       # ansible.verbose = "vvv"
-      ansible.playbook = "ansible/example-playbook.yml"
+      ansible.playbook = "ansible/pulp-from-source.yml"
   end
 
   # Create the "pulp3_dev" box

--- a/ansible/pulp-from-source.yml
+++ b/ansible/pulp-from-source.yml
@@ -1,4 +1,9 @@
 ---
+# Install Pulp 3 from source.
+#
+# The resultant installation is designed to be useful for developers. It does
+# things like install code in editable mode, install extra dependencies and
+# install Bash aliases.
 - hosts: pulp3_dev
   become: true
   become_method: sudo


### PR DESCRIPTION
Rename playbook from `example-playbook.yml` to `pulp-from-source.yml`.
Hopefully, this makes this playbook's effects more obvious: when run, it
will install Pulp from source. This also sets up a more obvious naming
scheme for future playbooks, such as `pulp-from-pypi.yml`.