### PR TITLE
Use a single variable to control dev extras

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -1,4 +1,1 @@
 ansible_python_interpreter: '/usr/bin/python3'
-# If enabled, `phelp` and other useful aliases are sourced by your bashrc.
-# In adition, some roles will add other relevant bashrc supplements
-supplement_bashrc: true

--- a/ansible/pulp-from-source.yml
+++ b/ansible/pulp-from-source.yml
@@ -7,6 +7,7 @@
 - hosts: pulp3_dev
   become: true
   vars:
+    pulp_install_strategy: development
     pulp_user: vagrant
   pre_tasks:
     # Developers want to know if Pulp works with the latest packages.

--- a/ansible/roles/dev/defaults/main.yml
+++ b/ansible/roles/dev/defaults/main.yml
@@ -1,2 +1,0 @@
-# non-essential requirements files listed in pulp_facts.py will be pip installed
-pip_install_extras: true

--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -30,7 +30,7 @@
       - test_requirements.txt
       - dev_requirements.txt
       - docs/requirements.txt
-    when: pip_install_extras
+    when: pulp_install_strategy == 'development'
 
   - name: Install Pulp Platform packages
     pip:
@@ -54,13 +54,15 @@
     copy:
       src: files/django.bashrc
       dest: "{{ pulp_user_home }}/.bashrc.d/django.bashrc"
-    when: supplement_bashrc
+    when: pulp_install_strategy == 'development'
 
   - name: Add virtualenv supplemental bashrc
     copy:
       src: files/venv.bashrc
       dest: "{{ pulp_user_home }}/.bashrc.d/venv.bashrc"
-    when: pulp_venv is defined and supplement_bashrc
+    when:
+      - pulp_venv is defined
+      - pulp_install_strategy == 'development'
   become: false
 
 - name: Create /etc/pulp directory

--- a/ansible/roles/pulp-user/README.md
+++ b/ansible/roles/pulp-user/README.md
@@ -26,6 +26,13 @@ The variables that this role uses, along with their default values, are listed
 below:
 
 ```yaml
+# The strategy to use when creating and configuring this user, and when
+# installing Pulp and its plugins. If "pypi," perform the minimum tasks needed
+# to create a functional Pulp installation. If "development," install code from
+# source in editable mode, install extra dependencies, install Bash aliases,
+# etc. If some other value, raise an error.
+pulp_install_strategy: pypi
+
 # The user that will host Pulp virtualenvs. This should be a dedicated user due
 # to security concerns. This user's home directory is made world-readable, among
 # other things.

--- a/ansible/roles/pulp-user/defaults/main.yml
+++ b/ansible/roles/pulp-user/defaults/main.yml
@@ -1,1 +1,2 @@
+pulp_install_strategy: pypi
 pulp_user: pulp

--- a/ansible/roles/pulp-user/tasks/main.yml
+++ b/ansible/roles/pulp-user/tasks/main.yml
@@ -7,20 +7,32 @@
       This role and those that depend on it require at least Python 3.5 and
       Ansible 2.2.
 
-# TODO: Only execute this when a development environment is being created.
+- name: Verify the value of the pulp_install_strategy variable
+  assert:
+    that: "pulp_install_strategy in ['pypi', 'development']"
+
 - name: Set the message of the day
   copy:
     src: motd
     dest: /etc/motd
+  when: pulp_install_strategy == 'development'
 
-# TODO: Only add user to systemd-journal group if a development environment is
-# being created.
+# We could initialize a pulp_user_groups variable as an empty list, append to it
+# depending on factors such as the pulp_install_strategy, and then write a
+# single task to create the pulp_user. But that introduces a new variable, and
+# the logic here is simple enough that that this seems like an OK approach.
+- name: Create user {{ pulp_user }} with development permissions
+  user:
+    name: "{{ pulp_user }}"
+    # Let the user read the system journal.
+    groups: systemd-journal
+    append: true
+  when: pulp_install_strategy == 'development'
+
 - name: Create user {{ pulp_user }}
   user:
     name: "{{ pulp_user }}"
-    # Let user read the system journal.
-    groups: systemd-journal
-    append: true
+  when: pulp_install_strategy != 'development'
 
 - name: Get user's home directory
   getent:
@@ -38,14 +50,15 @@
     state: directory
     mode: 0755
 
-# NOTE: This has horrible security implications. The `remote_user` that Ansible
-# connects as needs sudo priviliges. This user doesn't!
+# This has horrible security implications. It should *only* be done for
+# development installs.
 - name: Give user passwordless sudo privileges
   template:
     src: pulp-user-nopasswd.j2
     dest: /etc/sudoers.d/pulp-user-nopasswd
     validate: 'visudo -cf %s'
     mode: 0440
+  when: pulp_install_strategy == 'development'
 
 # TODO: Make variable names more canonical.
 # NOTE: "These variables will be available to subsequent plays during an
@@ -107,7 +120,7 @@
       create: yes
     become_user: "{{ pulp_user }}"
 
-  when: supplement_bashrc
+  when: pulp_install_strategy == 'development'
 
 - name: Create ~/.vimrc if not already present
   copy:

--- a/ansible/roles/smash/tasks/main.yml
+++ b/ansible/roles/smash/tasks/main.yml
@@ -38,5 +38,5 @@
     copy:
       src: files/smash.bashrc
       dest: "{{ pulp_user_home }}/.bashrc.d/smash.bashrc"
-    when: supplement_bashrc
+    when: pulp_install_strategy == 'development'
   become: false


### PR DESCRIPTION
Drop the `pip_install_extras` and `supplement_bashrc` variables. In
their place, add a variable named `pulp_install_strategy`:

> The strategy to use when creating and configuring this user, and when
> installing Pulp and its plugins. If "barebones," perform the minimum
> tasks needed to create a functional Pulp installation. If
> "development," install code from source in editable mode, install
> extra dependencies, install Bash aliases, etc. If some other value,
> raise an error.

Why do this? Well, consider what might happen if we want to support the
use case of installing Pulp in a different manner — say, from source,
but not in editable mode or with developer tools. How would this be
done?

With the current strategy, we might need to add another variable called
`install_from_source` or `pip_install_source` or somesuch. While this
might work, this produces an exponential increase in the number of
variable combinations. With n variables, there are 2^n variable
combinations. (Or more, if a variable isn't a boolean.) And presumably,
many of those combinations wouldn't be valid.

By using a single variable to control how Pulp is installed, the number
of variable combinations scales linearly. If there are three values for
the `pulp_install_strategy` variable, then there are three variable
values to test out. Hopefully, this is also more straightforward and
easy to understand.