### PR TITLE
Publish ansible roles to install pulp3

### DIFF
--- a/deploy_pulp3/README.md
+++ b/deploy_pulp3/README.md
@@ -1,0 +1,6 @@
+1. install ansible2.2+, python3, virtualenv, libselinux-python
+2. download roles from galaxy
+   ansible-galaxy install -r requirements.yml -p ./roles
+3. run the playbook by specifying which broker you want rabbitmq|qpidd
+   ansible-playbook deploy-pulp3.yml --extra-vars "pulp3_broker=rabbitmq"
+

--- a/deploy_pulp3/deploy-pulp3.yml
+++ b/deploy_pulp3/deploy-pulp3.yml
@@ -1,0 +1,20 @@
+---
+- hosts: all
+  become: true
+  vars:
+    ansible_python_interpreter: "/usr/bin/python3"
+  pre_tasks:
+    - name: Require minimal Python and Ansible versions
+      assert:
+        that:
+          - "ansible_python_version|version_compare('3.5.0', operator='ge')"
+          - "ansible_version.full|version_compare('2.2.0', operator='ge')"
+        msg: >
+          This role and those that depend on it require at least Python 3.5 and
+          Ansible 2.2.
+  roles:
+    - pulp3
+    - pulp3_db
+    - pulp3_systemd
+    - { role: rabbitmq, when: pulp3_broker == "rabbitmq"}
+    - { role: qpid_cpp_server, when: pulp3_broker == "qpidd"}

--- a/deploy_pulp3/pulp3/defaults/main.yml
+++ b/deploy_pulp3/pulp3/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+pulp_user: pulp

--- a/deploy_pulp3/pulp3/files/django.bashrc
+++ b/deploy_pulp3/pulp3/files/django.bashrc
@@ -1,0 +1,1 @@
+export DJANGO_SETTINGS_MODULE=pulpcore.app.settings

--- a/deploy_pulp3/pulp3/tasks/main.yml
+++ b/deploy_pulp3/pulp3/tasks/main.yml
@@ -1,0 +1,107 @@
+---
+- name: Create user {{ pulp_user }}
+  user:
+    name: "{{ pulp_user }}"
+    comment: "Pulp user"
+
+- name: Get user's info
+  getent:
+    database: passwd
+    key: "{{ pulp_user }}"
+
+- name: Set variable referencing user's home directory
+  set_fact:
+    pulp_user_home: "{{ getent_passwd[pulp_user][4] }}"
+
+- name: Make user's home directory world-readable
+  file:
+    path: "{{ pulp_user_home }}"
+    state: directory
+    mode: 0755
+
+- name: Set variable referencing pulpvenv dir
+  set_fact:
+    pulp_venv: "{{ pulp_user_home }}/pulpvenv"
+
+- name: Create ~/.bashrc.d/
+  file:
+    path: "{{ pulp_user_home }}/.bashrc.d/"
+    state: directory
+  become_user: "{{ pulp_user }}"
+
+- name: Create directory /var/lib/pulp
+  file:
+    path: /var/lib/pulp
+    state: directory
+    owner: "{{ pulp_user }}"
+    group: "{{ pulp_user }}"
+    mode: 0775
+
+- name: Install pulpcore
+  pip:
+    name: pulpcore
+    state: present
+    virtualenv: "{{ pulp_venv }}"
+    virtualenv_python: python3
+  become_user: "{{ pulp_user }}"
+
+- name: Add Django supplemental bashrc
+  copy:
+    src: files/django.bashrc
+    dest: "{{pulp_user_home}}/.bashrc.d/django.bashrc"
+    owner: "{{ pulp_user }}"
+    group: "{{ pulp_user }}"
+
+- name: Source  ~/.bashrc.d/
+  blockinfile:
+    path: "{{ pulp_user_home }}/.bashrc"
+    block: |
+      if [ -d ~/.bashrc.d ]; then
+        for file in ~/.bashrc.d/*; do
+          . "$file"
+        done
+      fi
+    marker: "# {mark} Ansible managed block: source bashrc.d/"
+    create: yes
+  become_user: "{{ pulp_user }}"
+
+- name: Create /etc/pulp dir
+  file:
+    path: /etc/pulp
+    state: directory
+    owner: "{{ pulp_user }}"
+    group: "{{ pulp_user }}"
+
+- name : Find server.yaml config file
+  find:
+    paths: "{{ pulp_venv }}"
+    patterns: 'server.yaml'
+    recurse: true
+  register: result
+
+- name: Ensure the server.yaml was found
+  assert:
+    that: 'result["matched"] == 1'
+
+- name: Install server.yaml Config file
+  copy:
+    remote_src: true
+    src: '{{ result["files"][0]["path"] }}'
+    dest: "/etc/pulp/server.yaml"
+    owner: "{{ pulp_user }}"
+    group: "{{ pulp_user }}"
+    force: false
+
+- name: Generate random secret for Django
+  shell: cat /dev/urandom | tr -dc 'a-z0-9!@#$%^&*(\-_=+)' | head -c 50
+  check_mode: false
+  changed_when: false
+  register: random_secret
+
+- name: Add development server configuration in server.yaml
+  blockinfile:
+    path: "/etc/pulp/server.yaml"
+    block: |
+      # Pulp Development Configuration
+      DEBUG: True
+      SECRET_KEY: {{ random_secret.stdout | to_nice_yaml }}

--- a/deploy_pulp3/pulp3_db/files/pg_hba.conf
+++ b/deploy_pulp3/pulp3_db/files/pg_hba.conf
@@ -1,0 +1,14 @@
+# PostgreSQL Client Authentication Configuration File
+# ===================================================
+#
+# Refer to the "Client Authentication" section in the PostgreSQL
+# documentation for a complete description of this file.
+
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+# "local" is for Unix domain socket connections only
+local   all             all                                     peer
+# IPv4 local connections:
+host    all             all             127.0.0.1/32            trust
+# IPv6 local connections:
+host    all             all             ::1/128                 trust

--- a/deploy_pulp3/pulp3_db/tasks/main.yml
+++ b/deploy_pulp3/pulp3_db/tasks/main.yml
@@ -1,0 +1,68 @@
+- name: Install postgres packages
+  package: name={{ item }} state=present
+  with_items:
+      - postgresql
+      - postgresql-server
+      # needed by postgres-related tasks and other things
+      # using python outside of a virtualenv
+      - python3-psycopg2
+
+- name: Set up postgres data dir
+  command: postgresql-setup --initdb
+  args:
+      creates: /var/lib/pgsql/data/base
+
+- name: Set up postgress access rules
+  copy:
+      src: pg_hba.conf
+      dest: /var/lib/pgsql/data/pg_hba.conf
+      owner: postgres
+      group: postgres
+      mode: 0600
+
+- name: Start and enable postgresql
+  service: name=postgresql state=started enabled=yes
+
+- name: Set up pulp DB user
+  postgresql_user:
+      name: "{{ pulp_user }}"
+      role_attr_flags: SUPERUSER,LOGIN
+  become: true
+  become_user: postgres
+
+- name: Create pulp database
+  postgresql_db:
+      name: "{{ pulp_user }}"
+      owner: "{{ pulp_user }}"
+  become: true
+  become_user: postgres
+
+- name : Find manage.py
+  find:
+    paths: "{{ pulp_venv }}"
+    patterns: 'manage.py'
+    recurse: true
+  register: result
+
+- name: Ensure the manage.py was found
+  assert:
+    that: 'result["matched"] == 1'
+
+- name: Changing perm of manage.py, adding "+x"
+  file: dest={{ result["files"][0]["path"] }} mode=a+x
+
+- name: Run Django migrations
+  django_manage:
+    command: "{{ item }}"
+    app_path: '{{ result["files"][0]["path"]| dirname}}'
+    virtualenv: "{{ pulp_user_home }}/pulpvenv"
+  with_items:
+    - 'makemigrations pulp_app'
+    - 'migrate --noinput auth'
+    - 'migrate --noinput'
+    - 'reset-admin-password --password admin'
+  become: true
+  become_user: "{{ pulp_user }}"
+
+- name: Changing perm of manage.py, adding "-x"
+  file: dest={{ result["files"][0]["path"] }} mode=a-x

--- a/deploy_pulp3/pulp3_systemd/tasks/main.yml
+++ b/deploy_pulp3/pulp3_systemd/tasks/main.yml
@@ -1,0 +1,30 @@
+- name: Install Systemd unit files
+  # The template allows us to specify the platform python environment.
+  template:
+      src: "templates/{{ item }}.j2"
+      dest: "/etc/systemd/system/{{ item }}.service"
+  with_items:
+    - pulp_celerybeat
+    - pulp_resource_manager
+    - pulp_worker@
+  register: result
+ 
+- name: Create /var/cache/pulp directory
+  file:
+    path: /var/cache/pulp
+    state: directory
+    owner: "{{ pulp_user }}"
+    group: "{{ pulp_user }}"
+
+- name: reload systemd units
+  systemd:
+    daemon-reload: yes
+    name: "{{ item }}"
+    state: restarted
+    enabled: yes
+  with_items:
+    - pulp_celerybeat
+    - pulp_resource_manager
+    - pulp_worker@1
+    - pulp_worker@2
+  when: result|changed

--- a/deploy_pulp3/pulp3_systemd/templates/pulp_celerybeat.j2
+++ b/deploy_pulp3/pulp3_systemd/templates/pulp_celerybeat.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Pulp's Celerybeat
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+EnvironmentFile=-/etc/default/pulp_celerybeat
+User={{ pulp_user }}
+WorkingDirectory=/var/run/pulp_celerybeat/
+RuntimeDirectory=pulp_celerybeat
+ExecStart={{ pulp_venv }}/bin/celery beat --app=pulpcore.tasking.celery_app:celery --scheduler=pulpcore.tasking.services.scheduler.Scheduler
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy_pulp3/pulp3_systemd/templates/pulp_resource_manager.j2
+++ b/deploy_pulp3/pulp3_systemd/templates/pulp_resource_manager.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=Pulp Resource Manager
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+EnvironmentFile=-/etc/default/pulp_resource_manager
+User={{ pulp_user }}
+WorkingDirectory=/var/run/pulp_resource_manager/
+RuntimeDirectory=pulp_resource_manager
+ExecStart={{ pulp_venv }}/bin/celery worker -A pulpcore.tasking.celery_app:celery -n resource_manager@%%h\
+          -Q resource_manager -c 1 --events --umask 18\
+          --pidfile=/var/run/pulp_resource_manager/resource_manager.pid
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy_pulp3/pulp3_systemd/templates/pulp_worker@.j2
+++ b/deploy_pulp3/pulp3_systemd/templates/pulp_worker@.j2
@@ -1,0 +1,17 @@
+[Unit]
+Description=Pulp Celery Worker
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+EnvironmentFile=-/etc/default/pulp_workers
+EnvironmentFile=-/etc/default/pulp_workers_%i
+User={{ pulp_user }}
+WorkingDirectory=/var/run/pulp_worker_%i/
+RuntimeDirectory=pulp_worker_%i
+ExecStart={{ pulp_venv }}/bin/celery worker -A pulpcore.tasking.celery_app:celery\
+          -n reserved_resource_worker_%i@%%h -c 1 --events --umask 18\
+          --pidfile=/var/run/pulp_worker_%i/reserved_resource_worker_%i.pid
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy_pulp3/requirements.yml
+++ b/deploy_pulp3/requirements.yml
@@ -1,0 +1,13 @@
+# Install roles from the Ansible Galaxy
+- src: ipanova.pulp3
+  name: pulp3
+- src: ipanova.pulp3_db
+  name: pulp3_db
+- src: ipanova.pulp3_systemd
+  name: pulp3_systemd
+- src: jtyr.config_encoder_filters
+  name: config_encoder_filters
+- src: jtyr.rabbitmq
+  name: rabbitmq
+- src: jtyr.qpid_cpp_server
+  name: qpid_cpp_server


### PR DESCRIPTION
closes #2840

1. pulp3, pulp3_db, pulp3_systemd will be eventually published to the galaxy
2. pulp3_migrations role still needs to be written and published to the galaxy
3. rabbitmq and qpidd roles from jtyr needs to be adopted for python3 (AI: reach jtyr)
4. the docs from readme will be moved as a separate PR to pulp/pulp installation section.