### PR TITLE
Drop unnecessary directive from Ansible playbook

### DIFF
--- a/ansible/pulp-from-source.yml
+++ b/ansible/pulp-from-source.yml
@@ -6,7 +6,6 @@
 # install Bash aliases.
 - hosts: pulp3_dev
   become: true
-  become_method: sudo
   vars:
     pulp_user: vagrant
   pre_tasks:


### PR DESCRIPTION
The default value for `become_method` is "sudo." Don't re-declare this
option in the `pulp-from-source.yml` playbook. It's acts as unnecessary
noise that distracts readers from more interesting code.