### PR TITLE
Drop assertion from fact-gathering code

### DIFF
--- a/ansible/library/pulp_facts.py
+++ b/ansible/library/pulp_facts.py
@@ -50,10 +50,7 @@ def selinux_enforcing():
 
 
 def available_repositories(module):
-    """Find the source code for the Pulp platform and its plugins.
-
-    Raise an exception if the source code for the platform is absent.
-    """
+    """Find the source code for the Pulp platform and its plugins."""
     _available_repositories = []
     try:
         repos = os.listdir(module.params['devel_dir'])
@@ -63,13 +60,6 @@ def available_repositories(module):
         if (os.path.isdir(os.path.join(module.params['devel_dir'], repo)) and
                 repo in repositories):
             _available_repositories.append(repo)
-    if 'pulp' not in repos:
-        msg = (
-            'The source code for the Pulp platform must be present. However, '
-            '{} is either absent or is not a directory. Aborting.'
-            .format(os.path.join(module.params['devel_dir'], 'pulp'))
-        )
-        module.fail_json(name='pulp', msg=msg)
     return _available_repositories
 
 


### PR DESCRIPTION
When run by Ansible, `library/pulp_facts.py` exports a fact called
`pulp_available_repositories`. This fact is a list of all of the
directories in the ~/devel/ directory. When the fact-gathering code in
this module is executed, if the `pulp` directory is absent from
`pulp_available_repositories`, an exception is thrown. The idea is that
one can't install Pulp if this source code is missing.

This is problematic for two reasons.

First, this check is redundant. The `dev` role already asserts that
"pulp" is in `pulp_available_repositories`.

Second, this check makes the existing Ansible code more inflexible. What
if one wants to install Pulp not from locally available source code, but
directly from source code on GitHub, or from packages on PyPI? By
complaining about missing source code during the fact-gathering stage,
this code prevents any of those use cases from being realized.