### PR TITLE
Drop dependency on virtualenv executable

### DIFF
--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -26,6 +26,7 @@
     pip:
       requirements: "{{ pulp_devel_dir }}/pulp/{{ item }}"
       virtualenv: "{{ pulp_venv }}"
+      virtualenv_command: /usr/bin/python3 -m venv
     with_items:
       - test_requirements.txt
       - dev_requirements.txt
@@ -37,6 +38,7 @@
       name: "{{ pulp_devel_dir }}/pulp/{{ item }}"
       extra_args: "-e"
       virtualenv: "{{ pulp_venv }}"
+      virtualenv_command: /usr/bin/python3 -m venv
     with_items:
         - common
         - platform

--- a/ansible/roles/plugins/tasks/main.yml
+++ b/ansible/roles/plugins/tasks/main.yml
@@ -3,6 +3,7 @@
     name: "{{ pulp_devel_dir }}/{{ item }}"
     extra_args: "-e"
     virtualenv: "{{ pulp_venv }}"
+    virtualenv_command: /usr/bin/python3 -m venv
   # If we stick with running setup.py develop for all plugins, we'd want to do it for all available
   # plugins. For now, it only works with pulp_file
   # with_items: "{{ pulp_available_plugins }}"

--- a/ansible/roles/smash/tasks/main.yml
+++ b/ansible/roles/smash/tasks/main.yml
@@ -19,6 +19,7 @@
   - name: Install pulp-smash requirements
     pip:
       virtualenv: "{{ pulp_smash_venv | default(omit) }}"
+      virtualenv_command: /usr/bin/python3 -m venv
       state: latest
       requirements: "{{ pulp_devel_dir }}/pulp-smash/{{ item }}"
       chdir: "{{ pulp_devel_dir }}/pulp-smash"


### PR DESCRIPTION
Python 3.3 and newer ships with the "venv" module, which is capable of
creating and managing virtualenvs. The virtualenv executable is only
needed if using an older version of Python.

Use `python -m venv` when creating virtualenvs. This drops the
dependency on the virtualenv executable. (And whatever packages provide
that executable.) Deployments of Pulp 3 will be faster and
more reliable if they use code that ships with the standard library
instead of third-party packages.