### PR TITLE
Make reset_db role more flexible

### DIFF
--- a/ansible/roles/reset_db/tasks/main.yml
+++ b/ansible/roles/reset_db/tasks/main.yml
@@ -1,2 +1,13 @@
-- name: Reset and Migrate Pulp DB
-  command: "{{ pulp_devel_dir }}/pulp/platform/pulpcore/app/db-reset.sh {{ pulp_venv }}"
+- name: Find db-reset.sh
+  find:
+    paths: "{{ pulp_venv }}"
+    recurse: true
+    patterns: 'db-reset.sh'
+  register: result
+
+- name: Assert one db-reset.sh file has been found
+  assert:
+    that: 'result["matched"] == 1'
+
+- name: Execute db-reset.sh
+  command: '{{ result["files"][0]["path"] }} {{ pulp_venv }}'


### PR DESCRIPTION
The `reset_db` role executes a script called `db-reset.sh`. If Pulp is
installed from PyPI or directly from git, then it won't exist in the
Pulp user's ~/devel/pulp directory. But no matter what type of
installation, it should exist in the virtualenv into which Pulp 3 is
installed.

Update the `reset_db` role so that it can find the `db-reset.sh` script
regardless of how Pulp 3 was installed.