### PR TITLE
Revert "Make reset_db role more flexible"

### DIFF
--- a/ansible/roles/reset_db/tasks/main.yml
+++ b/ansible/roles/reset_db/tasks/main.yml
@@ -1,13 +1,2 @@
-- name: Find db-reset.sh
-  find:
-    paths: "{{ pulp_venv }}"
-    recurse: true
-    patterns: 'db-reset.sh'
-  register: result
-
-- name: Assert one db-reset.sh file has been found
-  assert:
-    that: 'result["matched"] == 1'
-
-- name: Execute db-reset.sh
-  command: '{{ result["files"][0]["path"] }} {{ pulp_venv }}'
+- name: Reset and Migrate Pulp DB
+  command: "{{ pulp_devel_dir }}/pulp/platform/pulpcore/app/db-reset.sh {{ pulp_venv }}"


### PR DESCRIPTION
Reverts pulp/devel#87

The change fixed the pip/git installations, but broke "--editable" python installs (pip -e, setup.py develop). It turns out that the `*.egg-link` files created in dev installs aren't real symlinks, so this pattern won't work on dev installs.