### PR TITLE
Swap the rabbitmq and systemd roles.

### DIFF
--- a/ansible/deploy-pulp3.yml
+++ b/ansible/deploy-pulp3.yml
@@ -20,5 +20,5 @@
   roles:
     - pulp3
     - pulp3_db
-    - pulp3_systemd
     - rabbitmq
+    - pulp3_systemd


### PR DESCRIPTION
The systemd role will run as the last one, to be able to pick up
the rabbitmq config and not initiating with the celery default settings.