### PR TITLE
Require Ansible 2.3.2+

### DIFF
--- a/ansible/deploy-pulp3.yml
+++ b/ansible/deploy-pulp3.yml
@@ -13,10 +13,11 @@
       assert:
         that:
           - "ansible_python_version|version_compare('3.5.0', operator='ge')"
-          - "ansible_version.full|version_compare('2.2.0', operator='ge')"
+          - "ansible_version.full|version_compare('2.3.2', operator='ge')"
         msg: >
-          This role and those that depend on it require at least Python 3.5 and
-          Ansible 2.2.
+          This playbook requires Python 3.5+ and Ansible 2.3.2+. If your package
+          manager ships an older version of Ansible, consider creating a
+          virtualenv and installing Ansible with pip.
   roles:
     - pulp3
     - pulp3_db

--- a/ansible/roles/pulp-user/tasks/main.yml
+++ b/ansible/roles/pulp-user/tasks/main.yml
@@ -2,7 +2,7 @@
   assert:
     that:
       - "ansible_python_version|version_compare('3.5.0', operator='ge')"
-      - "ansible_version.full|version_compare('2.2.0', operator='ge')"
+      - "ansible_version.full|version_compare('2.3.2', operator='ge')"
     msg: >
       This role and those that depend on it require at least Python 3.5 and
       Ansible 2.2.


### PR DESCRIPTION
Ansible lets one create a virtualenv and install a package into it with
the `pip` module. Here's an example usage:

```yaml
- hosts: all
  tasks:
    - name: create virtualenv
      pip:
        name: flake8
        virtualenv: /tmp/test-venv
```

This works so long as the target hosts have Python 2 and the virtualenv
executable installed. Python 2 and virtualenv are required even when the
Ansible python interpreter is set to Python 3:

```yaml
- hosts: all
  vars:
    ansible_python_interpreter: /usr/bin/python3
  tasks:
    - name: create virtualenv
      pip:
        name: flake8
        virtualenv: /tmp/test-venv
```

In both of these cases, a missing dependency will throw an error stating
"Failed to find required executable virtualenv in paths: …". This makes
little sense in Pulp 3's case, as it requires Python 3. Why should the
installer for Pulp 3 require Python 2? A solution is to use the
`virtualenv_command` option to the `pip` module:

```yaml
- hosts: all
  tasks:
    - name: create virtualenv
      pip:
        name: flake8
        virtualenv: /tmp/test-venv
        virtualenv_command: /usr/bin/python3 -m venv
```

(`ansible_python_interpreter` may also be specified.) This can be done,
but only if Ansible 2.3.2+ is installed. Older versions of Ansible have
a bug that prevents this from working correctly. Possible solutions
include doing the following:

* Drop the usage of the venv module built in to Python 3 and re-add the
  dependency on python2-virtualenv
* Enforce the use of Ansible 2.3.2+ and suggest that users that don't
  have access to that through their package manager install Ansible from
  pip.

Given that all of Pulp 3's target platforms (RHEL 7, Fedora 25 and
Fedora 26) ship Ansible 2.3.2+, it seems reasonable to adopt the more
forward-looking solution.

See:

* https://github.com/ansible/ansible/blob/devel/CHANGELOG.md#232-ramble-on---2017-08-04
* https://github.com/ansible/ansible/pull/25241