### PR TITLE
Set the admin password after migrating the db

### DIFF
--- a/ansible/roles/django_db/tasks/reset.yml
+++ b/ansible/roles/django_db/tasks/reset.yml
@@ -4,4 +4,5 @@
     - "reset_db --noinput"
     - "migrate auth --noinput"
     - "migrate --noinput"
+    - "reset-admin-password --password admin"
   become: false

--- a/ansible/roles/pulp-user/templates/alias.bashrc
+++ b/ansible/roles/pulp-user/templates/alias.bashrc
@@ -41,6 +41,7 @@ pclean() {
     pulp-manager reset_db --noinput
     pulp-manager migrate auth --noinput
     pulp-manager migrate
+    pulp-manager reset-admin-password --password admin
 }
 _pclean_help="Restore pulp to a clean-installed state"
 # can get away with not resetting terminal settings here since it gets reset in phelp


### PR DESCRIPTION
We removed the db-reset.sh script from pulp which called reset-admin-password. Adding in that functionality here so that we don't have to manually call it after we `vagrant up` or `pclean`.