### PR TITLE
install platform and requirements before extras

### DIFF
--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -21,17 +21,6 @@
   when: pulp_venv is defined
 
 - block:
-  - name: Install developer extra-requirements
-    pip:
-      requirements: "{{ pulp_devel_dir }}/pulp/{{ item }}"
-      virtualenv: "{{ pulp_venv }}"
-      virtualenv_command: /usr/bin/python3 -m venv
-    with_items:
-      - test_requirements.txt
-      - dev_requirements.txt
-      - docs/requirements.txt
-    when: pip_install_extras
-
   - name: Install Pulp Platform packages
     pip:
       name: "{{ pulp_devel_dir }}/pulp/{{ item }}"
@@ -42,6 +31,17 @@
         - common
         - platform
         - plugin
+
+  - name: Install developer extra-requirements
+    pip:
+      requirements: "{{ pulp_devel_dir }}/pulp/{{ item }}"
+      virtualenv: "{{ pulp_venv }}"
+      virtualenv_command: /usr/bin/python3 -m venv
+    with_items:
+      - test_requirements.txt
+      - dev_requirements.txt
+      - docs/requirements.txt
+
 
   - name: Enable autoenv Directory Switching for pulp
     lineinfile:


### PR DESCRIPTION
Despite pinning the version of DRF https://github.com/pulp/pulp/pull/3185, we ended up with a different version because the requirements are installed in the wrong order.