### PR TITLE
Fix issue on Fedora 26

### DIFF
--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -27,7 +27,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # to browse that repository a bit to find the latest successful Vagrant image. For example, at the
   # time of this writing, I could set this setting like this for the latest F24 image:
   # config.vm.box = "https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/CloudImages/x86_64/images/<imagename>.vagrant-libvirt.box"
-  config.vm.box = "fedora/27-cloud-base"
+  config.vm.box = "fedora/26-cloud-base"
 
   # Comment out if you don't want Vagrant to add and remove entries from /etc/hosts for each VM.
   # requires the vagrant-hostmanager plugin to be installed
@@ -99,7 +99,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         override.vm.box = nil
         # Based on fedora official image, with vagrant's needs met:
         # https://github.com/rohanpm/docker-fedora-vagrant
-        d.image = 'rohanpm/fedora-vagrant:27'
+        d.image = 'rohanpm/fedora-vagrant:26'
 
         # use ssh for the sake of ansible
         d.has_ssh = true

--- a/ansible/roles/lazy/tasks/main.yml
+++ b/ansible/roles/lazy/tasks/main.yml
@@ -1,9 +1,10 @@
 ---
 - name: Install lazy packages
-  action: "{{ ansible_pkg_mgr }} name={{ item }} state=latest"
+  action: "{{ ansible_pkg_mgr }} name={{ item }} state=present"
   with_items:
       - squid
       - httpd
+      - mod_ssl
 
 - name: Install squid proxy configuration
   copy: src=squid.conf dest=/etc/squid/squid.conf

--- a/ansible/roles/pulp-certs/tasks/main.yml
+++ b/ansible/roles/pulp-certs/tasks/main.yml
@@ -4,7 +4,6 @@
 - name: Install openssl
   dnf: name={{ item }} state=present
   with_items:
-      - mod_ssl
       - openssl
       - openssl-perl
 


### PR DESCRIPTION
mod_ssl supports a slightly older z-release of httpd, so state=latest dnf creates an unresolvable conflict