### PR TITLE
Let dev playbook target all hosts

### DIFF
--- a/ansible/pulp-from-source.yml
+++ b/ansible/pulp-from-source.yml
@@ -4,7 +4,7 @@
 # The resultant installation is designed to be useful for developers. It does
 # things like install code in editable mode, install extra dependencies and
 # install Bash aliases.
-- hosts: pulp3_dev
+- hosts: all
   become: true
   vars:
     pulp_user: vagrant


### PR DESCRIPTION
The dev installer currently only targets hosts in the group `pulp3_dev`.
This requirement is inexplicable and annoying. It's inexplicable because
there is no hosts file. This is annoying because it prevents users from
easily using the playbook, such as like this:

    ansible-playbook pulp-from-source.yml -i fedora-26-pulp-3,

See: https://pulp.plan.io/issues/3318