### PR TITLE
Drop commented-out code

### DIFF
--- a/ansible/pulp-from-source.yml
+++ b/ansible/pulp-from-source.yml
@@ -33,11 +33,6 @@
     - lazy
     - dev
     - {role: plugin, plugin_name: 'pulp_file', app_label: 'pulp_file'}
-    # - {role: plugin, plugin_name: 'pulp_example', app_label: 'pulp_example'}
+    # - {role: plugin, plugin_name: 'pulp_python', app_label: 'pulp_python'}
     - systemd
-    # - pulp_ca
-    # - smash
-    # - pulpproject
     - dev_tools
-    # - release
-    # - debug


### PR DESCRIPTION
Leaving commented-out code lying around is messy:

* Commented-out code distracts from the actual, working code.
* If someone needs to know how to write a playbook, they can look at the
  Ansible documentation, or existing code in `pulp-from-source.yml` or
  `deploy-pulp3.yml`.
* If someone needs to know the past state of this playbook, they can use
  git.