### PR TITLE
Remove the use of include

### DIFF
--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -128,8 +128,15 @@
     group: "{{ pulp_user }}"
     mode: 0755
 
-- include: roles/django_db/tasks/makemigrations.yml app_label=pulp_app
-- include: roles/django_db/tasks/reset.yml
+- include_role:
+    name: django_db
+    tasks_from: makemigrations
+  vars:
+    app_label: pulp_app
+
+- include_role:
+    name: django_db
+    tasks_from: reset
 
 - include_role:
     name: kombu_fixup

--- a/ansible/roles/plugin/tasks/main.yml
+++ b/ansible/roles/plugin/tasks/main.yml
@@ -15,6 +15,11 @@
     become: false
 
   # variables plugin_name and app_label are passed implicitly
-  - include: roles/django_db/tasks/makemigrations.yml
-  - include: roles/django_db/tasks/reset.yml
+  - include_role:
+      name: django_db
+      tasks_from: makemigrations
+
+  - include_role:
+      name: django_db
+      tasks_from: reset
   when: repo_path.stat.isdir is defined and repo_path.stat.isdir


### PR DESCRIPTION
`include` is deprecated and it's future is uncertain. We should remove it.
See http://docs.ansible.com/ansible/latest/include_module.html#deprecated.