### PR TITLE
Don't assume that Ansible logs in as vagrant user

### DIFF
--- a/ansible/pulp-from-source.yml
+++ b/ansible/pulp-from-source.yml
@@ -5,7 +5,6 @@
 # things like install code in editable mode, install extra dependencies and
 # install Bash aliases.
 - hosts: all
-  become: true
   vars:
     pulp_user: vagrant
     use_rabbitmq: False
@@ -15,6 +14,9 @@
       package:
         name: '*'
         state: latest
+      become: true
+      tags:
+        - skip_ansible_lint
   roles:
     - pulp-user
     - db

--- a/ansible/roles/broker/tasks/main.yml
+++ b/ansible/roles/broker/tasks/main.yml
@@ -1,23 +1,33 @@
-- name: Install Qpid packages
-  package: name={{ item }} state=present
-  with_items:
-    - qpid-cpp-server
-  when: use_rabbitmq == False
+- block:
 
-- name: Start and enable Qpid services
-  service: name={{ item }} state=started enabled=yes
-  with_items:
-    - qpidd
-  when: use_rabbitmq == False
+  - name: Install rabbitmq
+    package:
+      name: rabbitmq-server
+      state: present
 
-- name: Install rabbitmq packages
-  package: name={{ item }} state=present
-  with_items:
-    - rabbitmq-server
-  when: use_rabbitmq == True
+  - name: Start rabbitmq
+    systemd:
+      name: rabbitmq-server
+      state: started
+      enabled: yes
+      daemon_reload: yes
 
-- name: Start and enable rabbitmq services
-  service: name={{ item }} state=started enabled=yes
-  with_items:
-    - rabbitmq-server
-  when: use_rabbitmq == True
+  become: true
+  when: use_rabbitmq
+
+- block:
+
+  - name: Install qpid
+    package:
+      name: qpid-cpp-server
+      state: present
+
+  - name: Start qpid
+    systemd:
+      name: qpidd
+      state: started
+      enabled: yes
+      daemon_reload: yes
+
+  become: true
+  when: not use_rabbitmq

--- a/ansible/roles/db/tasks/main.yml
+++ b/ansible/roles/db/tasks/main.yml
@@ -1,35 +1,46 @@
-- name: Install postgres packages
-  package: name={{ item }} state=present
-  with_items:
+- block:
+
+  - name: Install postgres packages
+    package:
+      name: '{{ item }}'
+      state: present
+    with_items:
       - postgresql
       - postgresql-server
       # needed by postgres-related tasks and other things
       # using python outside of a virtualenv
       - python3-psycopg2
 
-- name: Set up postgres data dir
-  # avoid https://code.djangoproject.com/ticket/18710
-  shell: PGSETUP_INITDB_OPTIONS='--encoding UTF-8' postgresql-setup --initdb
-  args:
+  - name: Set up postgres data dir
+    # avoid https://code.djangoproject.com/ticket/18710
+    command: postgresql-setup --initdb
+    environment:
+      PGSETUP_INITDB_OPTIONS: --encoding UTF-8
+    args:
       creates: /var/lib/pgsql/data/base
 
-- name: Set up postgress access rules
-  copy:
+  - name: Set up postgress access rules
+    copy:
       src: pg_hba.conf
       dest: /var/lib/pgsql/data/pg_hba.conf
       owner: postgres
       group: postgres
       mode: 0600
 
-- name: Start and enable postgresql
-  service: name=postgresql state=restarted enabled=yes
+  - name: Start and enable postgresql
+    systemd:
+      name: postgresql
+      state: restarted
+      enabled: yes
 
-- name: Set up pulp DB user
-  postgresql_user:
+  - name: Set up pulp DB user
+    postgresql_user:
       name: pulp
       role_attr_flags: SUPERUSER,LOGIN
 
-- name: Create pulp database
-  postgresql_db:
+  - name: Create pulp database
+    postgresql_db:
       name: pulp
       owner: pulp
+
+  become: true

--- a/ansible/roles/dev/handlers/main.yml
+++ b/ansible/roles/dev/handlers/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: restart sshd
-  service:
-      name: sshd
-      state: restarted
+  systemd:
+    name: sshd
+    state: restarted
+  become: true

--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -4,44 +4,51 @@
     repo: https://github.com/pulp/pulp.git
     version: '3.0-dev'
     update: false
+  become: true
   become_user: '{{ pulp_user }}'
 
-- name: Install python SELinux bindings for the Ansible SELinux module
-  package:
-    name: "{{ item }}"
-  with_items:
-    - libselinux-python3
-    - selinux-policy
+- block:
 
-- name: Disable selinux
-  selinux: state=disabled
+  - name: Install python SELinux bindings for the Ansible SELinux module
+    package:
+      name:
+        - libselinux-python3
+        - selinux-policy
+      state: present
 
-- name: Disable sshd strict modes
-  lineinfile:
+  - name: Disable selinux
+    selinux:
+      state: disabled
+
+  - name: Disable sshd strict modes
+    lineinfile:
       backrefs: yes
       dest: /etc/ssh/sshd_config
-      regexp: "^#StrictModes yes"
-      line: "StrictModes no"
-  notify: restart sshd
+      regexp: '^#StrictModes yes'
+      line: 'StrictModes no'
+    notify: restart sshd
 
-- name: Install python-virtualenvwrapper
-  package:
-    name: "{{ item }}"
-  with_items:
-    # workaround a dependency bug of python3-virtualenvwrapper
-    - which
-    - python3-virtualenvwrapper
-    # the python2 version is required for mkvenv as mkvenv
-    # doesn't seem to respect the VIRTUALENVWRAPPER_PYTHON variable
-    - python2-virtualenvwrapper
-  when: pulp_venv is defined
+  - name: Install python-virtualenvwrapper
+    package:
+      name:
+        # workaround a dependency bug of python3-virtualenvwrapper
+        - which
+        - python3-virtualenvwrapper
+        # the python2 version is required for mkvenv as mkvenv
+        # doesn't seem to respect the VIRTUALENVWRAPPER_PYTHON variable
+        - python2-virtualenvwrapper
+      state: present
+    when: pulp_venv is defined
+
+  become: true
 
 - block:
+
   - name: Install Pulp Platform packages
     pip:
-      name: "{{ pulp_devel_dir }}/pulp/{{ item }}"
-      extra_args: "-e"
-      virtualenv: "{{ pulp_venv }}"
+      name: '{{ pulp_devel_dir }}/pulp/{{ item }}'
+      extra_args: '-e'
+      virtualenv: '{{ pulp_venv }}'
       virtualenv_command: /usr/bin/python3 -m venv
     with_items:
       - common
@@ -50,8 +57,8 @@
 
   - name: Install developer extra-requirements
     pip:
-      requirements: "{{ pulp_devel_dir }}/pulp/{{ item }}"
-      virtualenv: "{{ pulp_venv }}"
+      requirements: '{{ pulp_devel_dir }}/pulp/{{ item }}'
+      virtualenv: '{{ pulp_venv }}'
       virtualenv_command: /usr/bin/python3 -m venv
     with_items:
       - test_requirements.txt
@@ -59,75 +66,82 @@
       - docs/requirements.txt
       - pulpcore/doc_requirements.txt
 
-
   - name: Enable autoenv Directory Switching for pulp
     lineinfile:
-      dest: "{{ pulp_venv }}/.project"
-      line: "{{ pulp_devel_dir }}/pulp"
+      dest: '{{ pulp_venv }}/.project'
+      line: '{{ pulp_devel_dir }}/pulp'
       create: true
-      regexp: ".*"
+      regexp: '.*'
     when: pulp_venv is defined
 
   - name: Add Django supplemental bashrc
     copy:
       src: files/django.bashrc
-      dest: "{{ pulp_user_home }}/.bashrc.d/django.bashrc"
+      dest: '{{ pulp_user_home }}/.bashrc.d/django.bashrc'
     when: supplement_bashrc
 
   - name: Add virtualenv supplemental bashrc
     copy:
       src: files/venv.bashrc
-      dest: "{{ pulp_user_home }}/.bashrc.d/venv.bashrc"
+      dest: '{{ pulp_user_home }}/.bashrc.d/venv.bashrc'
     when: pulp_venv is defined and supplement_bashrc
-  become: false
 
-- name: Create /etc/pulp directory
-  file:
-    path: /etc/pulp
-    state: directory
-
-- name: Install server.yaml Config file
-  copy:
-    remote_src: true
-    src: "{{pulp_devel_dir}}/pulp/pulpcore/pulpcore/etc/pulp/server.yaml"
-    dest: "/etc/pulp/server.yaml"
+  become: true
+  become_user: '{{ pulp_user }}'
 
 - name: Generate random secret for Django
   shell: cat /dev/urandom | tr -dc 'a-z0-9!@#$%^&*(\-_=+)' | head -c 50
   register: random_secret
+  tags:
+    - skip_ansible_lint
 
-- name: Add development server configuration in server.yaml
-  blockinfile:
-    path: "/etc/pulp/server.yaml"
-    block: |
-      # Pulp Development Configuration
-      DEBUG: True
-      SECRET_KEY: "{{ random_secret.stdout }}"
+- block:
 
-- name: Add Qpid broker settings override in server.yaml
-  blockinfile:
-    path: "/etc/pulp/server.yaml"
-    marker: "# {mark} QPID SETTINGS OVERRIDE BLOCK"
-    block: |
-      broker:
-        url: qpid://localhost/
-  when: use_rabbitmq == False
+  - name: Create /etc/pulp directory
+    file:
+      path: /etc/pulp
+      state: directory
 
-- name: Create /var/lib/pulp directory
-  file:
-    path: /var/lib/pulp
-    state: directory
-    owner: "{{ pulp_user }}"
-    group: "{{ pulp_user }}"
-    mode: 0755
+  - name: Install server.yaml Config file
+    copy:
+      remote_src: true
+      src: '{{pulp_devel_dir}}/pulp/pulpcore/pulpcore/etc/pulp/server.yaml'
+      dest: '/etc/pulp/server.yaml'
 
-- name: Create /var/lib/pulp/tmp directory
-  file:
-    path: /var/lib/pulp/tmp
-    state: directory
-    owner: "{{ pulp_user }}"
-    group: "{{ pulp_user }}"
-    mode: 0755
+  - name: Add development server configuration in server.yaml
+    blockinfile:
+      path: '/etc/pulp/server.yaml'
+      block: |
+        # Pulp Development Configuration
+        DEBUG: True
+        SECRET_KEY: '{{ random_secret.stdout }}'
+
+  - name: Add Qpid broker settings override in server.yaml
+    blockinfile:
+      path: '/etc/pulp/server.yaml'
+      marker: '# {mark} QPID SETTINGS OVERRIDE BLOCK'
+      block: |
+        broker:
+          url: qpid://localhost/
+    when: use_rabbitmq == False
+
+  - name: Create /var/lib/pulp directory
+    file:
+      path: /var/lib/pulp
+      state: directory
+      owner: '{{ pulp_user }}'
+      group: '{{ pulp_user }}'
+      mode: 0755
+
+  - name: Create /var/lib/pulp/tmp directory
+    file:
+      path: /var/lib/pulp/tmp
+      state: directory
+      owner: '{{ pulp_user }}'
+      group: '{{ pulp_user }}'
+      mode: 0755
+
+  become: true
 
 - include_role:
     name: django_db

--- a/ansible/roles/dev_tools/tasks/main.yml
+++ b/ansible/roles/dev_tools/tasks/main.yml
@@ -5,31 +5,36 @@
 
 # Fedora has a packaging problem where vim-enhanced will fail to install if
 # vim-minimal is out of date.
-- name: Upgrade vim-minimal
-  package: name=vim-minimal state=latest
+- block:
 
-- name: Install optional useful packages
-  package: name={{ item }} state=latest
-  with_items:
-      # System packages useful for most developers
-      - bash-completion
-      - fedora-easy-karma
-      - htop
-      - screen
-      - tmux
-      - tree
-      - vim-enhanced
-      - dstat
-      - fpaste
-      - iotop
-      - jnettop
-      - httpie
-      - jq
-      - python-django-bash-completion
-      - redhat-lsb-core
-      - telnet
-      - yum-utils
-      # Python packages useful for developers
-      - python-ipdb
-      - python3-setuptools
-      - python-rpdb
+  - name: Install latest version of vim-minimal
+    package:
+      name: vim-minimal
+      state: latest
+
+  - name: Install latest version of several useful packages
+    package:
+      name:
+        - bash-completion
+        - dstat
+        - fedora-easy-karma
+        - fpaste
+        - htop
+        - httpie
+        - iotop
+        - jnettop
+        - jq
+        - python-django-bash-completion
+        - python-ipdb
+        - python-rpdb
+        - python3-setuptools
+        - redhat-lsb-core
+        - screen
+        - telnet
+        - tmux
+        - tree
+        - vim-enhanced
+        - yum-utils
+      state: latest
+
+  become: true

--- a/ansible/roles/django_db/tasks/makemigrations.yml
+++ b/ansible/roles/django_db/tasks/makemigrations.yml
@@ -1,3 +1,4 @@
 - name: makemigrations
-  command: "{{pulp_venv}}/bin/pulp-manager makemigrations {{app_label}}"
-  become: false
+  command: '{{ pulp_venv }}/bin/pulp-manager makemigrations {{ app_label }}'
+  become: true
+  become_user: '{{ pulp_user }}'

--- a/ansible/roles/django_db/tasks/reset.yml
+++ b/ansible/roles/django_db/tasks/reset.yml
@@ -1,8 +1,9 @@
 - name: migrate
-  command: "{{pulp_venv}}/bin/pulp-manager {{item}}"
+  command: '{{pulp_venv}}/bin/pulp-manager {{item}}'
   with_items:
-    - "reset_db --noinput"
-    - "migrate auth --noinput"
-    - "migrate --noinput"
-    - "reset-admin-password --password admin"
-  become: false
+    - reset_db --noinput
+    - migrate auth --noinput
+    - migrate --noinput
+    - reset-admin-password --password admin
+  become: true
+  become_user: '{{ pulp_user }}'

--- a/ansible/roles/kombu_fixup/tasks/main.yml
+++ b/ansible/roles/kombu_fixup/tasks/main.yml
@@ -1,38 +1,49 @@
-- name: "Uninstall the Kombu we received from PyPI"
-  pip:
-    state: absent
-    name: kombu
-    virtualenv: "{{ pulp_venv }}"
-    virtualenv_command: /usr/bin/python3 -m venv
+- block:
 
-- name: "Install kombu from source"
-  pip:
-    name: "git+https://github.com/bmbouter/kombu.git@624-convert-qpid-to-amqp-1.0#egg=kombu"
-    extra_args: "-e"
-    virtualenv: "{{ pulp_venv }}"
-    virtualenv_command: /usr/bin/python3 -m venv
+  - name: Uninstall the Kombu we received from PyPI
+    pip:
+      state: absent
+      name: kombu
+      virtualenv: '{{ pulp_venv }}'
+      virtualenv_command: /usr/bin/python3 -m venv
 
-- name: "Install system packages proton needs"
-  package: name={{ item }} state=present
+  - name: Install kombu from source
+    pip:
+      name: git+https://github.com/bmbouter/kombu.git@624-convert-qpid-to-amqp-1.0#egg=kombu
+      extra_args: '-e'
+      virtualenv: '{{ pulp_venv }}'
+      virtualenv_command: /usr/bin/python3 -m venv
+
+  become: true
+  become_user: '{{ pulp_user }}'
+
+- name: Install system packages proton needs
+  package:
+    name: '{{ item }}'
+    state: present
   with_items:
     - qpid-tools  # on system to provide 'qpid-stat' command
     - python-qpid-proton  # a required dependency of kombu
     - python3-devel  # allows for compilation during pip installs
     - gcc  # allows for compilation during pip installs
+  become: true
 
-- name: "clone the patched qpid-tools"
+- name: Clone the patched qpid-tools
   git:
-    repo: 'https://github.com/bmbouter/qpid-cpp'
+    repo: https://github.com/bmbouter/qpid-cpp
     dest: /tmp/qpid-cpp
     version: qpid-for-pulp
 
-- name: "Install qpid-tools from source"
-  command: "{{ pulp_venv }}/bin/python3 setup.py install"
+- name: Install qpid-tools from source
+  command: '{{ pulp_venv }}/bin/python3 setup.py install'
   args:
-    chdir: "/tmp/qpid-cpp/management/python"
+    chdir: /tmp/qpid-cpp/management/python
+  become: true
 
-- name: "Install python-qpid-proton from PyPI"
+- name: Install python-qpid-proton from PyPI
   pip:
-    name: "python-qpid-proton"
-    virtualenv: "{{ pulp_venv }}"
+    name: python-qpid-proton
+    virtualenv: '{{ pulp_venv }}'
     virtualenv_command: /usr/bin/python3 -m venv
+  become: true
+  become_user: '{{ pulp_user }}'

--- a/ansible/roles/lazy/tasks/main.yml
+++ b/ansible/roles/lazy/tasks/main.yml
@@ -1,13 +1,29 @@
-- name: Install lazy packages
-  package: name={{ item }} state=present
-  with_items:
-      - squid
-      - httpd
+- block:
 
-- name: Install Squid proxy configuration
-  copy: src=squid.conf dest=/etc/squid/squid.conf
+  - name: Install lazy packages
+    package:
+      name:
+        - httpd
+        - squid
+      state: present
 
-- file: path=/var/spool/squid state=directory owner=squid group=squid mode=750
+  - name: Install Squid proxy configuration
+    copy:
+      src: squid.conf
+      dest: /etc/squid/squid.conf
 
-- name: Start and enable Squid service
-  service: name=squid state=started enabled=yes
+  - name: Create /var/spool/squid/
+    file:
+      path: /var/spool/squid
+      state: directory
+      owner: squid
+      group: squid
+      mode: 0750
+
+  - name: Start and enable Squid
+    systemd:
+      name: squid
+      state: started
+      enabled: yes
+
+  become: true

--- a/ansible/roles/plugin/tasks/main.yml
+++ b/ansible/roles/plugin/tasks/main.yml
@@ -1,18 +1,22 @@
 - stat:
-    path: "{{ pulp_devel_dir }}/{{ plugin_name }}"
+    path: '{{ pulp_devel_dir }}/{{ plugin_name }}'
   register: repo_path
+  become: true
+  become_user: '{{ pulp_user }}'
 
 - debug:
-    msg: "{{ pulp_devel_dir }}/{{ plugin_name }} does not exist, skipping!"
+    msg: '{{ pulp_devel_dir }}/{{ plugin_name }} does not exist, skipping!'
   when: repo_path.stat.isdir is not defined or not repo_path.stat.isdir
 
 - block:
-  - name: Install Plugin packages into core Pulp Python environment
+
+  - name: Install plugin packages into core Pulp Python environment
     pip:
-      name: "{{ pulp_devel_dir }}/{{ plugin_name }}"
-      extra_args: "-e"
-      virtualenv: "{{ pulp_venv }}"
-    become: false
+      name: '{{ pulp_devel_dir }}/{{ plugin_name }}'
+      extra_args: '-e'
+      virtualenv: '{{ pulp_venv }}'
+    become: true
+    become_user: '{{ pulp_user }}'
 
   # variables plugin_name and app_label are passed implicitly
   - include_role:
@@ -22,4 +26,5 @@
   - include_role:
       name: django_db
       tasks_from: reset
+
   when: repo_path.stat.isdir is defined and repo_path.stat.isdir

--- a/ansible/roles/pulp-user/tasks/main.yml
+++ b/ansible/roles/pulp-user/tasks/main.yml
@@ -12,6 +12,7 @@
   copy:
     src: motd
     dest: /etc/motd
+  become: true
 
 # TODO: Only add user to systemd-journal group if a development environment is
 # being created.
@@ -21,6 +22,7 @@
     # Let user read the system journal.
     groups: systemd-journal
     append: true
+  become: true
 
 - name: Get user's home directory
   getent:
@@ -37,15 +39,17 @@
     path: "{{ pulp_user_home }}"
     state: directory
     mode: 0755
+  become: true
 
 # NOTE: This has horrible security implications. The `remote_user` that Ansible
 # connects as needs sudo priviliges. This user doesn't!
-- name: Give user passwordless sudo privileges
+- name: Give {{ pulp_user }} passwordless sudo privileges
   template:
     src: pulp-user-nopasswd.j2
     dest: /etc/sudoers.d/pulp-user-nopasswd
     validate: 'visudo -cf %s'
     mode: 0440
+  become: true
 
 # TODO: Make variable names more canonical.
 # NOTE: "These variables will be available to subsequent plays during an
@@ -75,6 +79,7 @@
   with_items:
     - git
     - rpm-build
+  become: true
 
 - block:
 
@@ -82,13 +87,11 @@
     file:
       path: "{{ pulp_user_home }}/.bashrc.d/"
       state: directory
-    become_user: "{{ pulp_user }}"
 
   - name: Define developer aliases in ~/.bashrc.d/
     template:
       src: templates/alias.bashrc
       dest: "{{ pulp_user_home }}/.bashrc.d/alias.bashrc"
-    become_user: "{{ pulp_user }}"
 
   - name: Source developer aliases in ~/.bashrc.d/
     blockinfile:
@@ -101,20 +104,24 @@
         fi
       marker: "# {mark} Ansible managed block: source bashrc.d/"
       create: yes
-    become_user: "{{ pulp_user }}"
 
+  become: true
+  become_user: "{{ pulp_user }}"
   when: supplement_bashrc
 
-- name: Create ~/.vimrc if not already present
-  copy:
-    src: files/vimrc
-    dest: "{{ pulp_user_home }}/.vimrc"
-    force: no
-  become_user: "{{ pulp_user }}"
+- block:
 
-- name: Create ~/.netrc if not already present
-  copy:
-    src: files/netrc
-    dest: "{{ pulp_user_home }}/.netrc"
-    force: no
+  - name: Create ~/.vimrc if not already present
+    copy:
+      src: files/vimrc
+      dest: "{{ pulp_user_home }}/.vimrc"
+      force: no
+
+  - name: Create ~/.netrc if not already present
+    copy:
+      src: files/netrc
+      dest: "{{ pulp_user_home }}/.netrc"
+      force: no
+
+  become: true
   become_user: "{{ pulp_user }}"

--- a/ansible/roles/systemd/tasks/main.yml
+++ b/ansible/roles/systemd/tasks/main.yml
@@ -1,27 +1,30 @@
-- name: Install Systemd unit files
-  # The template allows us to specify the platform python environment.
-  template:
-      src: "templates/{{ item }}.j2"
-      dest: "/etc/systemd/system/{{ item }}.service"
-  with_items:
-    - pulp_resource_manager
-    - pulp_worker@
-- name: Create /var/cache/pulp directory
-  file:
-    path: /var/cache/pulp
-    state: directory
-    owner: "{{ pulp_user }}"
-    group: "{{ pulp_user }}"
+- block:
 
-- name: reload systemd units
-  command: systemctl daemon-reload
+  - name: Install Systemd unit files
+    # The template allows us to specify the platform python environment.
+    template:
+      src: 'templates/{{ item }}.j2'
+      dest: '/etc/systemd/system/{{ item }}.service'
+    with_items:
+      - pulp_resource_manager
+      - pulp_worker@
 
-- name: Start or Restart tasking services
-  service:
-      name: "{{ item }}"
-      state: restarted
+  - name: Create /var/cache/pulp directory
+    file:
+      path: /var/cache/pulp
+      state: directory
+      owner: '{{ pulp_user }}'
+      group: '{{ pulp_user }}'
+
+  - name: Start or Restart tasking services
+    systemd:
+      daemon_reload: true
       enabled: true
-  with_items:
+      name: '{{ item }}'
+      state: restarted
+    with_items:
+      - pulp_resource_manager
       - pulp_worker@1
       - pulp_worker@2
-      - pulp_resource_manager
+
+  become: true


### PR DESCRIPTION
Don't assume that Ansible logs in as a user called "vagrant." Instead,
assume that Ansible logs in as some user that has sudo access. This
makes non-Vagrant dev environments work better. And it's good practice
anyway!

See: https://pulp.plan.io/issues/3318