### PR TITLE
Require Ansible 2.4+

### DIFF
--- a/ansible/pulp-from-source.yml
+++ b/ansible/pulp-from-source.yml
@@ -9,6 +9,15 @@
     pulp_user: vagrant
     use_rabbitmq: False
   pre_tasks:
+    - name: Require minimal Python and Ansible versions
+      assert:
+        that:
+          - "ansible_python_version|version_compare('3.5.0', operator='ge')"
+          - "ansible_version.full|version_compare('2.4', operator='ge')"
+        msg: >
+          This playbook requires Python 3.5+ and Ansible 2.4+. If your package
+          manager ships an older version of Ansible, consider creating a
+          virtualenv and installing Ansible with pip.
     # Developers want to know if Pulp works with the latest packages.
     - name: Upgrade all currently installed packages
       package:

--- a/ansible/roles/pulp-user/tasks/main.yml
+++ b/ansible/roles/pulp-user/tasks/main.yml
@@ -1,12 +1,3 @@
-- name: Require minimal Python and Ansible versions
-  assert:
-    that:
-      - "ansible_python_version|version_compare('3.5.0', operator='ge')"
-      - "ansible_version.full|version_compare('2.3.2', operator='ge')"
-    msg: >
-      This role and those that depend on it require at least Python 3.5 and
-      Ansible 2.2.
-
 # TODO: Only execute this when a development environment is being created.
 - name: Set the message of the day
   copy:


### PR DESCRIPTION
Ansible 2.4 or newer is required to use the new `include_*` and
`import_*` statements. See: 4a01ead42270453b6ba17a7cea339685d1a2ee24

Also, move this check into the root playbook. This allows the following
roles to be re-ordered and re-written in crazy ways, without worrying
about losing this important pre-flight check.