### PR TITLE
Simplify django_db role

### DIFF
--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -143,15 +143,11 @@
 
   become: true
 
-- include_role:
+- name: Create and run migrations for {{ pulp_app }}
+  include_role:
     name: django_db
-    tasks_from: makemigrations
   vars:
     app_label: pulp_app
-
-- include_role:
-    name: django_db
-    tasks_from: reset
 
 - include_role:
     name: kombu_fixup

--- a/ansible/roles/django_db/README.md
+++ b/ansible/roles/django_db/README.md
@@ -1,0 +1,18 @@
+django\_db
+==========
+
+Create and run migrations
+
+When executed, this role will:
+
+1. Create migrations for the Pulp application with label `app_label`.
+2. Run all migrations.
+
+Sample invocation from a role:
+
+```yaml
+- include_role:
+    name: django_db
+  vars:
+    app_label: my_app
+```

--- a/ansible/roles/django_db/tasks/main.yml
+++ b/ansible/roles/django_db/tasks/main.yml
@@ -1,0 +1,15 @@
+- block:
+
+  - name: Make migrations for {{ app_label }}
+    command: '{{ pulp_venv }}/bin/pulp-manager makemigrations {{ app_label }}'
+
+  - name: Run all migrations
+    command: '{{ pulp_venv }}/bin/pulp-manager {{ item }}'
+    with_items:
+      - reset_db --noinput
+      - migrate auth --noinput
+      - migrate --noinput
+      - reset-admin-password --password admin
+
+  become: true
+  become_user: '{{ pulp_user }}'

--- a/ansible/roles/django_db/tasks/makemigrations.yml
+++ b/ansible/roles/django_db/tasks/makemigrations.yml
@@ -1,4 +1,0 @@
-- name: makemigrations
-  command: '{{ pulp_venv }}/bin/pulp-manager makemigrations {{ app_label }}'
-  become: true
-  become_user: '{{ pulp_user }}'

--- a/ansible/roles/django_db/tasks/reset.yml
+++ b/ansible/roles/django_db/tasks/reset.yml
@@ -1,9 +1,0 @@
-- name: migrate
-  command: '{{pulp_venv}}/bin/pulp-manager {{item}}'
-  with_items:
-    - reset_db --noinput
-    - migrate auth --noinput
-    - migrate --noinput
-    - reset-admin-password --password admin
-  become: true
-  become_user: '{{ pulp_user }}'

--- a/ansible/roles/plugin/tasks/main.yml
+++ b/ansible/roles/plugin/tasks/main.yml
@@ -18,13 +18,10 @@
     become: true
     become_user: '{{ pulp_user }}'
 
-  # variables plugin_name and app_label are passed implicitly
-  - include_role:
+  # Variables in the current context are inherited by included roles. Thus, this
+  # role implicitly gets the app_label variable that it needs.
+  - name: Run migrations for {{ app_label }}
+    include_role:
       name: django_db
-      tasks_from: makemigrations
-
-  - include_role:
-      name: django_db
-      tasks_from: reset
 
   when: repo_path.stat.isdir is defined and repo_path.stat.isdir


### PR DESCRIPTION
The `django_db` role has two task files, neither of which is named
`main.yml`. This makes role invocation verbose and repetitive:

```yaml
- name: Make migrations for {{ pulp_app }}
  include_role:
    name: django_db
    tasks_from: makemigrations
  vars:
    app_label: pulp_app

- name: Run migrations
  include_role:
    name: django_db
    tasks_from: reset
```

Simplify the role, so that it can be invoked like so:

```yaml
- name: Make and run migrations for {{ pulp_app }}
  include_role:
    name: django_db
  vars:
    app_label: pulp_app
```

This is much more concise, and it works well for all current use cases.
It has a downside: If a caller wants to create several migrations and
run them all in one go, then this role doesn't allow for that. If this
situation arises, though, it can be addressed by letting the role accept
an `app_labels` var instead of an `app_label` var.