### PR TITLE
Fix linting issues, enable Travis checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: false
+language: python
+python:
+  - 3.5
+  - 3.6
+install:
+  - pip install ansible-lint
+script:
+  - ansible-lint ansible/pulp-from-source.yml
+cache: pip

--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -155,6 +155,7 @@
   vars:
     app_label: pulp_app
 
-- include_role:
+- name: Install a custom version of Kombu
+  include_role:
     name: kombu_fixup
   when: use_rabbitmq == False

--- a/ansible/roles/dev_tools/tasks/main.yml
+++ b/ansible/roles/dev_tools/tasks/main.yml
@@ -11,6 +11,8 @@
     package:
       name: vim-minimal
       state: latest
+    tags:
+      - skip_ansible_lint
 
   - name: Install latest version of several useful packages
     package:
@@ -36,5 +38,7 @@
         - vim-enhanced
         - yum-utils
       state: latest
+    tags:
+      - skip_ansible_lint
 
   become: true

--- a/ansible/roles/plugin/tasks/main.yml
+++ b/ansible/roles/plugin/tasks/main.yml
@@ -1,4 +1,5 @@
-- stat:
+- name: Get information about {{ pulp_devel_dir }}/{{ plugin_name }}
+  stat:
     path: '{{ pulp_devel_dir }}/{{ plugin_name }}'
   register: repo_path
   become: true


### PR DESCRIPTION
The first commit fixes all remaining warnings emitted by ansible-lint. The second adds a `.travis.yml`.