### PR TITLE
Adding sqlite binary to dev env

### DIFF
--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -40,6 +40,12 @@
       state: present
     when: pulp_venv is defined
 
+  - name: Install sqlite
+    package:
+      name:
+        - sqlite
+      state: present
+
   become: true
 
 - block:


### PR DESCRIPTION
The `dbshell` command wasn't working because it requires the binary
client. This will ensure that on dev installs at least that will work.

https://pulp.plan.io/issues/3359
re #3359