### PR TITLE
Specify all rpm deps

### DIFF
--- a/ansible/library/pulp_facts.py
+++ b/ansible/library/pulp_facts.py
@@ -19,49 +19,14 @@ pipe = subprocess.Popen('/usr/sbin/getenforce', stdout=subprocess.PIPE,
 stdout, stderr = pipe.communicate()
 selinux_enabled = 'Enforcing' in stdout
 
-# Determine the list of RPM dependencies
-projects = [
-    'crane',
-    'pulp',
-    'pulp_deb',
-    'pulp_docker',
-    'pulp_openstack',
-    'pulp_ostree',
-    'pulp_puppet',
-    'pulp_python',
-    'pulp_rpm'
-]
-rpm_dependency_list = set()
-# This is run using sudo, but the code is checked out in the normal user directory.
-user_homedir = pwd.getpwuid(int(os.environ['SUDO_UID'])).pw_dir
-for project in projects:
-    project_path = os.path.join(user_homedir, 'devel', project)
-    if os.path.isdir(project_path):
-        # Determine the dependencies by inspecting the 'Requires' in each spec file.
-        # The results are then filtered to only include packages not provided by Pulp.
-        rpmspec_command = r"rpmspec -q --queryformat '[%{REQUIRENEVRS}\n]' " + project_path + \
-                          '/*.spec' + r'| grep -v "/.*" | grep -v "python-pulp.*" | ' \
-                          r'grep -v "^pulp.*"'
-        proc = subprocess.Popen(rpmspec_command, stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE, shell=True)
-        stdout, stderr = proc.communicate()
-        rpm_dependency_list.update(rpm.split()[0] for rpm in stdout.splitlines())
-
-# Replace python-lxml with python2-lxml
-# https://www.redhat.com/archives/pulp-dev/2016-December/msg00042.html
-if 'python-lxml' in rpm_dependency_list:
-    rpm_dependency_list.discard('python-lxml')
-    rpm_dependency_list.add('python2-lxml')
-
-# python-debpkgr is being installed via pip in pulp-dev.py
-rpm_dependency_list.discard('python-debpkgr')
+rpm_dependency_list = list(['nss-tools', 'pygobject3', 'deltarpm', 'kobo', 'puppet', 'python2-lxml', 'python-ldap', 'crontabs', 'httpd', 'systemd', 'git', 'mod_ssl', 'python-pycurl', 'python-oauth2', 'policycoreutils-python', 'python-isodate', 'python-nectar', 'libselinux-python', 'python-blinker', 'python-iniparse', 'python-flask', 'mod_wsgi', 'repoview', 'python-mongoengine', 'python-setuptools', 'python-django', 'python', 'python-deltarpm', 'python-rhsm', 'rsync', 'pyliblzma', 'python-httplib2', 'm2crypto', 'genisoimage', 'createrepo', 'python-twisted', 'python-qpid', 'mod_xsendfile', 'python-twine', 'selinux-policy', 'python-pymongo', 'python-gnupg', 'gofer', 'ostree', 'python-semantic_version', 'openssl', 'acl', 'createrepo_c', 'yum', 'python-okaara', 'gnupg', 'python-gofer', 'python-celery'])
 
 # Build the facts for Ansible
 facts = {
     'ansible_facts': {
         'pulp_nightly_repo_enabled': pulp_nightly_repo_enabled,
         'selinux_enabled': selinux_enabled,
-        'pulp_rpm_dependencies': list(rpm_dependency_list),
+        'pulp_rpm_dependencies': rpm_dependency_list,
     }
 }
 


### PR DESCRIPTION
The spec files were recently removed from the repos of all of the
plugins which breaks the pulp2 dev env that would inspect them. This is
a hard-list of the dependencies and will allow the dev env to continue
working.

There is not an issue associated with the spec file change so this PR
also does not have an issue.