### PR TITLE
Drop redundant variable declaration

### DIFF
--- a/ansible/deploy-pulp3.yml
+++ b/ansible/deploy-pulp3.yml
@@ -3,7 +3,6 @@
 - hosts: all
   become: true
   vars:
-    ansible_python_interpreter: "/usr/bin/python3"
     rabbitmq_config:
       - rabbit:
         - tcp_listeners:


### PR DESCRIPTION
`group_vars/all` already declared `ansible_python_interpreter`. Don't
declare it again in the `deploy-pulp3.yml` playbook.