### PR TITLE
Don't install "latest" version of packages

### DIFF
--- a/ansible/pulp-from-source.yml
+++ b/ansible/pulp-from-source.yml
@@ -18,14 +18,6 @@
           This playbook requires Python 3.5+ and Ansible 2.4+. If your package
           manager ships an older version of Ansible, consider creating a
           virtualenv and installing Ansible with pip.
-    # Developers want to know if Pulp works with the latest packages.
-    - name: Upgrade all currently installed packages
-      package:
-        name: '*'
-        state: latest
-      become: true
-      tags:
-        - skip_ansible_lint
   roles:
     - pulp-user
     - db

--- a/ansible/roles/dev_tools/tasks/main.yml
+++ b/ansible/roles/dev_tools/tasks/main.yml
@@ -1,20 +1,22 @@
-# This role could be made more idempotent by requesting that packages be
-# "present," not "latest." The vim packaging issue could be solved with logic
-# that says "if the current platform is Fedora and vim-enhanced isn't installed,
-# let vim-minimal be latest."
-
-# Fedora has a packaging problem where vim-enhanced will fail to install if
-# vim-minimal is out of date.
 - block:
 
-  - name: Install latest version of vim-minimal
+  # Fedora 26 docker has a packaging problem where vim-enhanced will fail to
+  # install if vim-minimal is out of date.
+  - name: Try to install vim-enhanced
+    package:
+      name: vim-enhanced
+      state: present
+    register: result
+
+  - name: Upgrade vim-minimal if installing vim-enhanced failed
     package:
       name: vim-minimal
       state: latest
+    when: result.failed
     tags:
       - skip_ansible_lint
 
-  - name: Install latest version of several useful packages
+  - name: Install several useful packages
     package:
       name:
         - bash-completion
@@ -37,8 +39,6 @@
         - tree
         - vim-enhanced
         - yum-utils
-      state: latest
-    tags:
-      - skip_ansible_lint
+      state: present
 
   become: true


### PR DESCRIPTION
When installing packages, assert that necessary packages are "present,"
not "latest." The justification for installing the latest versions of
packages is that the devs want to know if Pulp 3 works with the latest
packages. However:

* Upgrading to the latest versions of packages makes the install take
  longer.
* Upgrading to the latest versions of packages makes installs
  non-idempotent.
* If a dev wants an up-to-date set of packages, it's as easy as logging
  in and executing `dnf -y update`. And the developers are likely to
  start building fresh Vagrant images daily in the near future.