### PR TITLE
Don't require Python 3.5+

### DIFF
--- a/ansible/pulp-from-source.yml
+++ b/ansible/pulp-from-source.yml
@@ -9,15 +9,13 @@
     pulp_user: vagrant
     use_rabbitmq: False
   pre_tasks:
-    - name: Require minimal Python and Ansible versions
+    - name: Require Ansible 2.4+
       assert:
         that:
-          - "ansible_python_version|version_compare('3.5.0', operator='ge')"
-          - "ansible_version.full|version_compare('2.4', operator='ge')"
+          - ansible_version.full|version_compare('2.4', operator='ge')
         msg: >
-          This playbook requires Python 3.5+ and Ansible 2.4+. If your package
-          manager ships an older version of Ansible, consider creating a
-          virtualenv and installing Ansible with pip.
+          This playbook requires Ansible 2.4+. Consider creating a virtualenv
+          and installing Ansible with pip.
   roles:
     - pulp-user
     - db


### PR DESCRIPTION
It's entirely possible to install Pulp 3 on a host for which the
`ansible_python_interpreter` is older than Python 3.5. What matters is
that Python 3.5+ can be made available. For example, on
RHEL 7, the default Python interpreter is Python 2.7, but Python 3.5 can
be installed via an SCL, and Pulp can be installed into a virtualenv
that uses the SCL Python.