### PR TITLE
Install dep for python-qpid-proton on Fedora cloud

### DIFF
--- a/ansible/roles/kombu_fixup/tasks/main.yml
+++ b/ansible/roles/kombu_fixup/tasks/main.yml
@@ -26,6 +26,7 @@
     - python-qpid-proton  # a required dependency of kombu
     - python3-devel  # allows for compilation during pip installs
     - gcc  # allows for compilation during pip installs
+    - redhat-rpm-config  # dep for python-qpid-proton on Fedora cloud
   become: true
 
 - name: Clone the patched qpid-tools


### PR DESCRIPTION
python-qpid-proton depends on redhat-rpm-config on Fedora cloud images.

closes #3468
https://pulp.plan.io/issues/3468