### PR TITLE
Support Pulp 3 on RHEL 7

### DIFF
--- a/ansible/configure-rhel-7.yml
+++ b/ansible/configure-rhel-7.yml
@@ -1,0 +1,6 @@
+---
+- hosts: all
+  vars:
+    ansible_python_interpreter: /usr/bin/python2
+  roles:
+    - configure_rhel_7

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -1,4 +1,6 @@
 ansible_python_interpreter: '/usr/bin/python3'
+pulp_scl_enable_python3: '{% if ansible_distribution == "RedHat" %}/usr/bin/scl enable rh-python36 -- {% endif %}'
+pulp_python_interpreter: '{% if ansible_distribution == "RedHat" %}{{ pulp_scl_enable_python3 }} python3{% else %}/usr/bin/python3{% endif %}'
 # If enabled, `phelp` and other useful aliases are sourced by your bashrc.
 # In adition, some roles will add other relevant bashrc supplements
 supplement_bashrc: true

--- a/ansible/pulp-from-source.yml
+++ b/ansible/pulp-from-source.yml
@@ -24,4 +24,5 @@
     - {role: plugin, plugin_name: 'pulp_file', app_label: 'pulp_file'}
     # - {role: plugin, plugin_name: 'pulp_python', app_label: 'pulp_python'}
     - systemd
-    - dev_tools
+    - role: dev_tools
+      when: ansible_distribution == 'Fedora'

--- a/ansible/roles/configure_rhel_7/README.md
+++ b/ansible/roles/configure_rhel_7/README.md
@@ -1,0 +1,28 @@
+configure-rhel-7
+================
+
+Prepare the target RHEL 7 host for Pulp 3.
+
+Specifically, do the following:
+
+* Register and subscribe the host with subscription-manager. If registration
+  information has changed, configure which repositories are enabled.
+* Install the Python 3.5 SCL.
+
+The following variables may be specified:
+
+* *`rhn_pool`* A regular expression naming a pool, e.g. `'^SKU Name$'`.
+* *`rhn_username`* A username for registering the host.
+* *`rhn_password`* A password for registering the host.
+
+Sample playbook:
+
+```yaml
+- hosts: all
+  vars:
+    ansible_python_interpreter: "/usr/bin/python2"
+  vars_files:
+    - ~/Documents/rhn-credentials.yml
+  roles:
+    - configure-rhel-7
+```

--- a/ansible/roles/configure_rhel_7/tasks/main.yml
+++ b/ansible/roles/configure_rhel_7/tasks/main.yml
@@ -1,0 +1,67 @@
+---
+# `yum makecache` is called several times. This is done because yum isn't always
+# smart enough to know when it should update its cache, and the yum module's
+# `update_cache` option seems to have no effect.
+
+- name: Assert the target host runs Red Hat
+  assert:
+    that: ansible_distribution == 'RedHat'
+
+- name: Register and subscribe to {{ rhn_pool }}
+  redhat_subscription:
+    username: '{{ rhn_username }}'
+    password: '{{ rhn_password }}'
+    pool: '{{ rhn_pool }}'
+    state: present
+  when:
+    - rhn_pool is defined
+    - rhn_username is defined
+    - rhn_password is defined
+  become: true
+  register: result
+
+- block:
+
+  # Many repositories provide more up-to-date packages than the ones listed
+  # below. This can cause dependency resolution issues.
+  - name: Disable all repositories
+    command: subscription-manager repos --disable *
+
+  # rhel-server-rhscl-7-rpms provides Python 3 SCL. The others are frequently
+  # useful; they've been cargo-culted.
+  - name: Enable several official repositories
+    command: >
+      subscription-manager repos
+      --enable rhel-7-server-rpms
+      --enable rhel-7-server-extras-rpms
+      --enable rhel-7-server-optional-rpms
+      --enable rhel-server-rhscl-7-rpms
+
+  - name: Update yum's cache
+    command: yum -y makecache
+    tags:
+      - skip_ansible_lint
+
+  when: result|changed
+  become: true
+
+- name: Install Python 3.5 SCL
+  yum:
+    name: rh-python36
+    state: present
+  become: true
+
+# EPEL provides AMQP brokers. (RabbitMQ and Qpid.)
+- name: Enable EPEL repository
+  yum:
+    name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+    state: present
+  become: true
+  register: result
+
+- name: Update yum's cache
+  command: yum -y makecache
+  when: result|changed
+  become: true
+  tags:
+    - skip_ansible_lint

--- a/ansible/roles/db/tasks/main.yml
+++ b/ansible/roles/db/tasks/main.yml
@@ -1,25 +1,20 @@
 - block:
 
-  - name: Install postgres packages
+  - name: Install PostgreSQL
     package:
-      name: '{{ item }}'
+      name: postgresql-server
       state: present
-    with_items:
-      - postgresql
-      - postgresql-server
-      # needed by postgres-related tasks and other things
-      # using python outside of a virtualenv
-      - python3-psycopg2
 
-  - name: Set up postgres data dir
-    # avoid https://code.djangoproject.com/ticket/18710
-    command: postgresql-setup --initdb
+  # Set environment variable to avoid encoding issues. See:
+  # https://code.djangoproject.com/ticket/18710
+  - name: Set up PostgreSQL data directory
+    command: postgresql-setup {% if ansible_distribution == "Fedora" %}--{% endif %}initdb
     environment:
       PGSETUP_INITDB_OPTIONS: --encoding UTF-8
     args:
       creates: /var/lib/pgsql/data/base
 
-  - name: Set up postgress access rules
+  - name: Set up PostgreSQL access rules
     copy:
       src: pg_hba.conf
       dest: /var/lib/pgsql/data/pg_hba.conf
@@ -27,18 +22,23 @@
       group: postgres
       mode: 0600
 
-  - name: Start and enable postgresql
+  - name: Start and enable PostgreSQL
     systemd:
       name: postgresql
-      state: restarted
-      enabled: yes
+      state: started
+      enabled: true
 
-  - name: Set up pulp DB user
+  - name: Install bindings required by the postgresql_* Ansible modules
+    package:
+      name: python{% if ansible_distribution == "Fedora" %}3{% endif %}-psycopg2
+      state: present
+
+  - name: Set up database user for Pulp
     postgresql_user:
       name: pulp
       role_attr_flags: SUPERUSER,LOGIN
 
-  - name: Create pulp database
+  - name: Create database for Pulp
     postgresql_db:
       name: pulp
       owner: pulp

--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -9,12 +9,13 @@
 
 - block:
 
-  - name: Install python SELinux bindings for the Ansible SELinux module
+  - name: Install bindings required by the Ansible SELinux module (Fedora)
     package:
       name:
-        - libselinux-python3
+        - libselinux-python{% if ansible_distribution == "Fedora" %}3{% endif %}
         - selinux-policy
       state: present
+    when: ansible_distribution == 'Fedora'
 
   - name: Disable selinux
     selinux:
@@ -28,34 +29,59 @@
       line: 'StrictModes no'
     notify: restart sshd
 
+  # The python2 version is required for mkvenv as mkvenv doesn't seem to respect
+  # the VIRTUALENVWRAPPER_PYTHON variable.
   - name: Install python-virtualenvwrapper
     package:
+      name: python-virtualenvwrapper
+    when: pulp_venv is defined
+
+  # Ther is or was a dependency bug with the python3-virtualenvwrapper package,
+  # and installing which works around it.
+  - name: Install python3-virtualenvwrapper (Fedora)
+    package:
       name:
-        # workaround a dependency bug of python3-virtualenvwrapper
         - which
         - python3-virtualenvwrapper
-        # the python2 version is required for mkvenv as mkvenv
-        # doesn't seem to respect the VIRTUALENVWRAPPER_PYTHON variable
-        - python2-virtualenvwrapper
-      state: present
-    when: pulp_venv is defined
+    when:
+      - pulp_venv is defined
+      - ansible_distribution == 'Fedora'
 
   - name: Install sqlite
     package:
-      name:
-        - sqlite
+      name: sqlite
       state: present
+
+  - name: Install tools for compiling a PostgreSQL database adapter
+    package:
+      name:
+        - gcc
+        - postgresql-devel
 
   become: true
 
 - block:
 
+  - name: Create pulp virtualenv
+    command: '{{ pulp_python_interpreter }} -m venv {{ pulp_venv }}'
+    args:
+      creates: '{{ pulp_venv }}'
+    register: result
+
+  - name: Update pip in virtualenv
+    pip:
+      name: pip
+      state: latest
+      executable: '{{ pulp_scl_enable_python3 }}{{ pulp_venv }}/bin/pip'
+    when: result|changed
+    tags:
+      - skip_ansible_lint
+
   - name: Install Pulp Platform packages
     pip:
       name: '{{ pulp_devel_dir }}/pulp/{{ item }}'
       extra_args: '-e'
-      virtualenv: '{{ pulp_venv }}'
-      virtualenv_command: /usr/bin/python3 -m venv
+      executable: '{{ pulp_scl_enable_python3 }}{{ pulp_venv }}/bin/pip'
     with_items:
       - common
       - pulpcore
@@ -64,8 +90,7 @@
   - name: Install developer extra-requirements
     pip:
       requirements: '{{ pulp_devel_dir }}/pulp/{{ item }}'
-      virtualenv: '{{ pulp_venv }}'
-      virtualenv_command: /usr/bin/python3 -m venv
+      executable: '{{ pulp_scl_enable_python3 }}{{ pulp_venv }}/bin/pip'
     with_items:
       - test_requirements.txt
       - dev_requirements.txt

--- a/ansible/roles/django_db/tasks/main.yml
+++ b/ansible/roles/django_db/tasks/main.yml
@@ -1,10 +1,14 @@
 - block:
 
   - name: Make migrations for {{ app_label }}
-    command: '{{ pulp_venv }}/bin/pulp-manager makemigrations {{ app_label }}'
+    command: >
+      {{ pulp_scl_enable_python3 }}
+      {{ pulp_venv }}/bin/pulp-manager makemigrations {{ app_label }}
 
   - name: Run all migrations
-    command: '{{ pulp_venv }}/bin/pulp-manager {{ item }}'
+    command: >
+      {{ pulp_scl_enable_python3 }}
+      {{ pulp_venv }}/bin/pulp-manager {{ item }}
     with_items:
       - reset_db --noinput
       - migrate auth --noinput

--- a/ansible/roles/kombu_fixup/tasks/main.yml
+++ b/ansible/roles/kombu_fixup/tasks/main.yml
@@ -2,17 +2,15 @@
 
   - name: Uninstall the Kombu we received from PyPI
     pip:
-      state: absent
       name: kombu
-      virtualenv: '{{ pulp_venv }}'
-      virtualenv_command: /usr/bin/python3 -m venv
+      state: absent
+      executable: '{{ pulp_scl_enable_python3 }}{{ pulp_venv }}/bin/pip'
 
   - name: Install kombu from source
     pip:
       name: git+https://github.com/bmbouter/kombu.git@624-convert-qpid-to-amqp-1.0#egg=kombu
       extra_args: '-e'
-      virtualenv: '{{ pulp_venv }}'
-      virtualenv_command: /usr/bin/python3 -m venv
+      executable: '{{ pulp_scl_enable_python3 }}{{ pulp_venv }}/bin/pip'
 
   become: true
   become_user: '{{ pulp_user }}'
@@ -24,7 +22,7 @@
   with_items:
     - qpid-tools  # on system to provide 'qpid-stat' command
     - python-qpid-proton  # a required dependency of kombu
-    - python3-devel  # allows for compilation during pip installs
+    - '{% if ansible_distribution == "RedHat" %}rh-python36-python-devel{% else %}python3-devel{% endif %}'  # allows for compilation during pip installs
     - gcc  # allows for compilation during pip installs
     - redhat-rpm-config  # dep for python-qpid-proton on Fedora cloud
   become: true
@@ -36,7 +34,7 @@
     version: qpid-for-pulp
 
 - name: Install qpid-tools from source
-  command: '{{ pulp_venv }}/bin/python3 setup.py install'
+  command: '{{ pulp_scl_enable_python3 }}{{ pulp_venv }}/bin/python3 setup.py install'
   args:
     chdir: /tmp/qpid-cpp/management/python
   become: true
@@ -44,7 +42,6 @@
 - name: Install python-qpid-proton from PyPI
   pip:
     name: python-qpid-proton
-    virtualenv: '{{ pulp_venv }}'
-    virtualenv_command: /usr/bin/python3 -m venv
+    executable: '{{ pulp_scl_enable_python3 }}{{ pulp_venv }}/bin/pip'
   become: true
   become_user: '{{ pulp_user }}'

--- a/ansible/roles/plugin/tasks/main.yml
+++ b/ansible/roles/plugin/tasks/main.yml
@@ -15,7 +15,7 @@
     pip:
       name: '{{ pulp_devel_dir }}/{{ plugin_name }}'
       extra_args: '-e'
-      virtualenv: '{{ pulp_venv }}'
+      executable: '{{ pulp_scl_enable_python3 }}{{ pulp_venv }}/bin/pip'
     become: true
     become_user: '{{ pulp_user }}'
 

--- a/ansible/roles/systemd/templates/pulp_resource_manager.j2
+++ b/ansible/roles/systemd/templates/pulp_resource_manager.j2
@@ -8,8 +8,9 @@ EnvironmentFile=-/etc/default/pulp_resource_manager
 User={{ pulp_user }}
 WorkingDirectory=/var/run/pulp_resource_manager/
 RuntimeDirectory=pulp_resource_manager
-ExecStart={{ pulp_venv }}/bin/celery worker -A pulpcore.tasking.celery_app:celery -n resource_manager@%%h\
-          -Q resource_manager -c 1 --events --umask 18\
+ExecStart={{ pulp_scl_enable_python3 }}{{ pulp_venv }}/bin/celery worker \
+          -A pulpcore.tasking.celery_app:celery -n resource_manager@%%h \
+          -Q resource_manager -c 1 --events --umask 18 \
           --pidfile=/var/run/pulp_resource_manager/resource_manager.pid
 
 [Install]

--- a/ansible/roles/systemd/templates/pulp_worker@.j2
+++ b/ansible/roles/systemd/templates/pulp_worker@.j2
@@ -9,8 +9,9 @@ EnvironmentFile=-/etc/default/pulp_workers_%i
 User={{ pulp_user }}
 WorkingDirectory=/var/run/pulp_worker_%i/
 RuntimeDirectory=pulp_worker_%i
-ExecStart={{ pulp_venv }}/bin/celery worker -A pulpcore.tasking.celery_app:celery\
-          -n reserved_resource_worker_%i@%%h -c 1 --events --umask 18\
+ExecStart={{ pulp_scl_enable_python3 }}{{ pulp_venv }}/bin/celery worker \
+          -A pulpcore.tasking.celery_app:celery \
+          -n reserved_resource_worker_%i@%%h -c 1 --events --umask 18 \
           --pidfile=/var/run/pulp_worker_%i/reserved_resource_worker_%i.pid
 
 [Install]


### PR DESCRIPTION
Add a new playbook, `configure-rhel-7.yml`, which takes care of
pre-installation tasks, like calling subscription-manager and enabling
the appropriate repositories.

Re-jigger all of the roles called by `pulp-from-source.yml`, so that
they can target either Fedora or RHEL 7. Notably, this required adding a
`pulp_python_interpreter` variable. This variable defaults to
`/usr/bin/python3` on Fedora and `/usr/bin/scl enable rh-python36 --
python3` on RHEL. Many Python invocations needed to be updated to take
this change in to account. The references to SCL are necessary because
the Python 3 provided by the standard repositories is version 3.4, but
Pulp 3 requires Python 3.5+.
    
The development environment doesn't totally work on RHEL 7. Certain
automatically-executed Bash scripts need to be updated. But in the mean
time, Pulp 3 at least works on RHEL 7.