### PR TITLE
Set .netrc to owner perms only

### DIFF
--- a/ansible/roles/pulp-user/tasks/main.yml
+++ b/ansible/roles/pulp-user/tasks/main.yml
@@ -110,6 +110,7 @@
       src: files/netrc
       dest: "{{ pulp_user_home }}/.netrc"
       force: no
+      mode: 0600
 
   become: true
   become_user: "{{ pulp_user }}"


### PR DESCRIPTION
When running ansible locally (for pulp_ansible) it refuses to run
saying:  ~/.netrc access too permissive: and then refusing to install
anything on the system.

This fixes the perms to 0600 which fixed the problem for my local
environment.