### PR TITLE
Switches default broker to RabbitMQ

### DIFF
--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -40,7 +40,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       ansible.playbook = "ansible/pulp-from-source.yml"
       # ansible.verbose = "vvv"
       # ansible.start_at_task = "ansible task name here"
-      # ansible.extra_vars = { use_rabbitmq: true }
+      # ansible.extra_vars = { use_rabbitmq: false }
   end
 
   # Create the "pulp3_dev" box

--- a/ansible/pulp-from-source.yml
+++ b/ansible/pulp-from-source.yml
@@ -7,7 +7,7 @@
 - hosts: all
   vars:
     pulp_user: vagrant
-    use_rabbitmq: False
+    use_rabbitmq: True
   pre_tasks:
     - name: Require Ansible 2.4+
       assert:


### PR DESCRIPTION
An deadlock issue with Pulp's cancellation has been discovered with the
Qpid/kombu code. We can still test the Qpid stack as that resolves, but
we shouldn't default into a known-broken environment.
