### PR TITLE
Drop unused code

### DIFF
--- a/ansible/deploy-pulp3.yml
+++ b/ansible/deploy-pulp3.yml
@@ -2,11 +2,6 @@
 # Install Pulp 3 from PyPi by using galaxy roles from requirements.yml
 - hosts: all
   become: true
-  vars:
-    rabbitmq_config:
-      - rabbit:
-        - tcp_listeners:
-          - '"localhost"': 5672
   pre_tasks:
     - name: Require minimal Python and Ansible versions
       assert:

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,11 +1,3 @@
 # Install roles from the Ansible Galaxy
 - src: pulp.pulp3
   name: pulp3
-- src: pulp.pulp3_db
-  name: pulp3_db
-- src: pulp.pulp3_systemd
-  name: pulp3_systemd
-- src: jtyr.config_encoder_filters
-  name: config_encoder_filters
-- src: jtyr.rabbitmq
-  name: rabbitmq


### PR DESCRIPTION
The `deploy-pulp.yml` playbook doesn't touch RabbitMQ in any way. Drop
the RabbitMQ configuration options from the playbook.

The `deploy-pulp.yml` playbook only uses the `pulp3` role. List only
that role in `requirements.yml`.