### PR TITLE
WIP: Fix issues in vagrant's provisioning of pulp-smash

### DIFF
--- a/scripts/vagrant-setup.sh
+++ b/scripts/vagrant-setup.sh
@@ -48,6 +48,7 @@ fi
 # If pulp-smash is present, set it up
 if [ -d pulp-smash ]; then
     echo "installing pulp-smash and its dependencies"
+    sudo yum install -y attr
     pushd pulp-smash
     ! mkvirtualenv pulp-smash --python=python3
     workon pulp-smash
@@ -55,17 +56,18 @@ if [ -d pulp-smash ]; then
     # Install dependencies
     pip install -r requirements.txt -r requirements-dev.txt
     pip install pytest
-    python3 setup.py develop
+    pip install --editable .[dev]
     mkdir -p $HOME/.config/pulp_smash/
     cat << EOF > $HOME/.config/pulp_smash/settings.json
 {
   "pulp": {
     "auth": ["admin", "admin"],
-    "version": "2.15"
+    "version": "2.15",
+    "selinux_enable": true
   },
   "systems": [
     {
-      "hostname": "https://$(hostname)",
+      "hostname": "$(hostname)",
       "roles": {
         "amqp broker": {
           "service": "qpidd"


### PR DESCRIPTION
# Summary

`psmash` tooling fails to run correctly with the workflow below (which I'm told is legit!).

 * Missing Python development dependencies from the pulp-smash.
 * Missing attrs commands (getfattr). Yum dependencies are missing.
 * Many "Name or service not found due" to incorrect hostname in settings produced by vagrant-setup.sh.


# Workflow

```
[laptop] $ mkdir ~/pulp-devel
[laptop] $ pushd ~/pulp-devel
[laptop] $ git clone git@github.com:pulp/devel.git
[laptop] $ git clone git@github.com:pulp/pulp.git
[laptop] $ git clone git@github.com:PulpQE/pulp-smash.git
[laptop] $ pushd devel
[laptop] $ vagrant up --provider=docker
[laptop] $ vagrant ssh
# begin failures.
[vagrant@pulp2] $ psmash
```

# Errors

## `make: flake8: Command not found`

After setting up a clean workspace, psmash doesn't work.

```
[vagrant@pulp2 ~]$ psmash
~ ~/devel/pulp-smash
flake8 . --ignore E501,F401 --exclude docs/_build
make: flake8: Command not found
make: *** [Makefile:40: lint-flake8] Error 127
~/devel/pulp-smash
```


#### Proof: `vagrant up` provisioning log excerpt

Notice many extras packages are not being installed. setup.py doesn't seem to have a way to ask for those packages to be installed. Specifically, it is missing the [extras_require packages](https://github.com/PulpQE/pulp-smash/blob/master/setup.py#L50).

```
pulp2_dev: installing pulp-smash and its dependencies
pulp2_dev: ~/devel/pulp-smash ~/devel ~
pulp2_dev: Using base prefix '/usr'
pulp2_dev: New python executable in /home/vagrant/.virtualenvs/pulp-smash/bin/python3
pulp2_dev: Also creating executable in /home/vagrant/.virtualenvs/pulp-smash/bin/python
pulp2_dev: Installing setuptools, pip, wheel...
pulp2_dev: done.
pulp2_dev: Running virtualenv with interpreter /bin/python3
pulp2_dev: virtualenvwrapper.user_scripts creating /home/vagrant/.virtualenvs/pulp-smash/bin/predeactivate
pulp2_dev: virtualenvwrapper.user_scripts creating /home/vagrant/.virtualenvs/pulp-smash/bin/postdeactivate
pulp2_dev: virtualenvwrapper.user_scripts creating /home/vagrant/.virtualenvs/pulp-smash/bin/preactivate
pulp2_dev: virtualenvwrapper.user_scripts creating /home/vagrant/.virtualenvs/pulp-smash/bin/postactivate
pulp2_dev: virtualenvwrapper.user_scripts creating /home/vagrant/.virtualenvs/pulp-smash/bin/get_env_details
pulp2_dev: Setting project for pulp-smash to /home/vagrant/devel/pulp-smash
pulp2_dev: Could not open requirements file: [Errno 2] No such file or directory: 'requirements.txt'
pulp2_dev: Collecting pytest
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/ed/96/271c93f75212c06e2a7ec3e2fa8a9c90acee0a4838dc05bf379ea09aae31/pytest-3.5.0-py2.py3-none-any.whl (194kB)
pulp2_dev: Collecting attrs>=17.4.0 (from pytest)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/b5/60/4e178c1e790fd60f1229a9b3cb2f8bc2f4cc6ff2c8838054c142c70b5adc/attrs-17.4.0-py2.py3-none-any.whl
pulp2_dev: Collecting pluggy<0.7,>=0.5 (from pytest)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/ba/65/ded3bc40bbf8d887f262f150fbe1ae6637765b5c9534bd55690ed2c0b0f7/pluggy-0.6.0-py3-none-any.whl
pulp2_dev: Collecting more-itertools>=4.0.0 (from pytest)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/7a/46/886917c6a4ce49dd3fff250c01c5abac5390d57992751384fe61befc4877/more_itertools-4.1.0-py3-none-any.whl (47kB)
pulp2_dev: Collecting py>=1.5.0 (from pytest)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/67/a5/f77982214dd4c8fd104b066f249adea2c49e25e8703d284382eb5e9ab35a/py-1.5.3-py2.py3-none-any.whl (84kB)
pulp2_dev: Requirement already satisfied: setuptools in /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages (from pytest) (39.0.1)
pulp2_dev: Collecting six>=1.10.0 (from pytest)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/67/4b/141a581104b1f6397bfa78ac9d43d8ad29a7ca43ea90a2d863fe3056e86a/six-1.11.0-py2.py3-none-any.whl
pulp2_dev: Installing collected packages: attrs, pluggy, six, more-itertools, py, pytest
pulp2_dev: Successfully installed attrs-17.4.0 more-itertools-4.1.0 pluggy-0.6.0 py-1.5.3 pytest-3.5.0 six-1.11.0
pulp2_dev: running develop
pulp2_dev: running egg_info
pulp2_dev: writing pulp_smash.egg-info/PKG-INFO
pulp2_dev: writing dependency_links to pulp_smash.egg-info/dependency_links.txt
pulp2_dev: writing entry points to pulp_smash.egg-info/entry_points.txt
pulp2_dev: writing requirements to pulp_smash.egg-info/requires.txt
pulp2_dev: writing top-level names to pulp_smash.egg-info/top_level.txt
pulp2_dev: reading manifest file 'pulp_smash.egg-info/SOURCES.txt'
pulp2_dev: reading manifest template 'MANIFEST.in'
pulp2_dev: writing manifest file 'pulp_smash.egg-info/SOURCES.txt'
pulp2_dev: running build_ext
pulp2_dev: Creating /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/pulp-smash.egg-link (link to .)
pulp2_dev: Adding pulp-smash 2018.4.12 to easy-install.pth file
pulp2_dev: Installing pulp-smash script to /home/vagrant/.virtualenvs/pulp-smash/bin
pulp2_dev:
pulp2_dev: Installed /home/vagrant/devel/pulp-smash
pulp2_dev: Processing dependencies for pulp-smash==2018.4.12
pulp2_dev: Searching for requests
pulp2_dev: Reading https://pypi.python.org/simple/requests/
pulp2_dev: Downloading https://files.pythonhosted.org/packages/49/df/50aa1999ab9bde74656c2919d9c0c085fd2b3775fd3eca826012bef76d8c/requests-2.18.4-py2.py3-none-any.whl#sha256=6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b
pulp2_dev: Best match: requests 2.18.4
pulp2_dev: Processing requests-2.18.4-py2.py3-none-any.whl
pulp2_dev: Installing requests-2.18.4-py2.py3-none-any.whl to /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages
pulp2_dev: writing requirements to /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/requests-2.18.4-py3.6.egg/EGG-INFO/requires.txt
pulp2_dev: Adding requests 2.18.4 to easy-install.pth file
pulp2_dev:
pulp2_dev: Installed /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/requests-2.18.4-py3.6.egg
pulp2_dev: Searching for pyxdg
pulp2_dev: Reading https://pypi.python.org/simple/pyxdg/
pulp2_dev: Downloading https://files.pythonhosted.org/packages/39/03/12eb9062f43adb94e30f366743cb5c83fd15fef026500cd4de42c7c12280/pyxdg-0.26-py2.py3-none-any.whl#sha256=1948ff8e2db02156c0cccd2529b43c0cff56ebaa71f5f021bbd755bc1419190e
pulp2_dev: Best match: pyxdg 0.26
pulp2_dev: Processing pyxdg-0.26-py2.py3-none-any.whl
pulp2_dev: Installing pyxdg-0.26-py2.py3-none-any.whl to /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages
pulp2_dev: Adding pyxdg 0.26 to easy-install.pth file
pulp2_dev:
pulp2_dev: Installed /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/pyxdg-0.26-py3.6.egg
pulp2_dev: Searching for python-dateutil
pulp2_dev: Reading https://pypi.python.org/simple/python-dateutil/
pulp2_dev: Downloading https://files.pythonhosted.org/packages/0c/57/19f3a65bcf6d5be570ee8c35a5398496e10a0ddcbc95393b2d17f86aaaf8/python_dateutil-2.7.2-py2.py3-none-any.whl#sha256=3220490fb9741e2342e1cf29a503394fdac874bc39568288717ee67047ff29df
pulp2_dev: Best match: python-dateutil 2.7.2
pulp2_dev: Processing python_dateutil-2.7.2-py2.py3-none-any.whl
pulp2_dev: Installing python_dateutil-2.7.2-py2.py3-none-any.whl to /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages
pulp2_dev: writing requirements to /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/python_dateutil-2.7.2-py3.6.egg/EGG-INFO/requires.txt
pulp2_dev: Adding python-dateutil 2.7.2 to easy-install.pth file
pulp2_dev:
pulp2_dev: Installed /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/python_dateutil-2.7.2-py3.6.egg
pulp2_dev: Searching for plumbum
pulp2_dev: Reading https://pypi.python.org/simple/plumbum/
pulp2_dev: Downloading https://files.pythonhosted.org/packages/b2/05/7720109462d0bd60466e74076a38ca12068771da146bfd18a502726c9da8/plumbum-1.6.6-py2.py3-none-any.whl#sha256=4b5af076fef56fe7345b67f7fa4c79185fa64ac5bc14a9de1aa1447b58b6cbd0
pulp2_dev: Best match: plumbum 1.6.6
pulp2_dev: Processing plumbum-1.6.6-py2.py3-none-any.whl
pulp2_dev: Installing plumbum-1.6.6-py2.py3-none-any.whl to /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages
pulp2_dev: Adding plumbum 1.6.6 to easy-install.pth file
pulp2_dev:
pulp2_dev: Installed /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/plumbum-1.6.6-py3.6.egg
pulp2_dev: Searching for packaging
pulp2_dev: Reading https://pypi.python.org/simple/packaging/
pulp2_dev: Downloading https://files.pythonhosted.org/packages/ad/c2/b500ea05d5f9f361a562f089fc91f77ed3b4783e13a08a3daf82069b1224/packaging-17.1-py2.py3-none-any.whl#sha256=e9215d2d2535d3ae866c3d6efc77d5b24a0192cce0ff20e42896cc0664f889c0
pulp2_dev: Best match: packaging 17.1
pulp2_dev: Processing packaging-17.1-py2.py3-none-any.whl
pulp2_dev: Installing packaging-17.1-py2.py3-none-any.whl to /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages
pulp2_dev: writing requirements to /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/packaging-17.1-py3.6.egg/EGG-INFO/requires.txt
pulp2_dev: Adding packaging 17.1 to easy-install.pth file
pulp2_dev:
pulp2_dev: Installed /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/packaging-17.1-py3.6.egg
pulp2_dev: Searching for jsonschema
pulp2_dev: Reading https://pypi.python.org/simple/jsonschema/
pulp2_dev: Downloading https://files.pythonhosted.org/packages/77/de/47e35a97b2b05c2fadbec67d44cfcdcd09b8086951b331d82de90d2912da/jsonschema-2.6.0-py2.py3-none-any.whl#sha256=000e68abd33c972a5248544925a0cae7d1125f9bf6c58280d37546b946769a08
pulp2_dev: Best match: jsonschema 2.6.0
pulp2_dev: Processing jsonschema-2.6.0-py2.py3-none-any.whl
pulp2_dev: Installing jsonschema-2.6.0-py2.py3-none-any.whl to /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages
pulp2_dev: writing requirements to /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/jsonschema-2.6.0-py3.6.egg/EGG-INFO/requires.txt
pulp2_dev: Adding jsonschema 2.6.0 to easy-install.pth file
pulp2_dev: Installing jsonschema script to /home/vagrant/.virtualenvs/pulp-smash/bin
pulp2_dev:
pulp2_dev: Installed /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/jsonschema-2.6.0-py3.6.egg
pulp2_dev: Searching for click
pulp2_dev: Reading https://pypi.python.org/simple/click/
pulp2_dev: Downloading https://files.pythonhosted.org/packages/34/c1/8806f99713ddb993c5366c362b2f908f18269f8d792aff1abfd700775a77/click-6.7-py2.py3-none-any.whl#sha256=29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d
pulp2_dev: Best match: click 6.7
pulp2_dev: Processing click-6.7-py2.py3-none-any.whl
pulp2_dev: Installing click-6.7-py2.py3-none-any.whl to /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages
pulp2_dev: Adding click 6.7 to easy-install.pth file
pulp2_dev:
pulp2_dev: Installed /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/click-6.7-py3.6.egg
pulp2_dev: Searching for urllib3<1.23,>=1.21.1
pulp2_dev: Reading https://pypi.python.org/simple/urllib3/
pulp2_dev: Downloading https://files.pythonhosted.org/packages/63/cb/6965947c13a94236f6d4b8223e21beb4d576dc72e8130bd7880f600839b8/urllib3-1.22-py2.py3-none-any.whl#sha256=06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b
pulp2_dev: Best match: urllib3 1.22
pulp2_dev: Processing urllib3-1.22-py2.py3-none-any.whl
pulp2_dev: Installing urllib3-1.22-py2.py3-none-any.whl to /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages
pulp2_dev: writing requirements to /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/urllib3-1.22-py3.6.egg/EGG-INFO/requires.txt
pulp2_dev: Adding urllib3 1.22 to easy-install.pth file
pulp2_dev:
pulp2_dev: Installed /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/urllib3-1.22-py3.6.egg
pulp2_dev: Searching for idna<2.7,>=2.5
pulp2_dev: Reading https://pypi.python.org/simple/idna/
pulp2_dev: Downloading https://files.pythonhosted.org/packages/27/cc/6dd9a3869f15c2edfab863b992838277279ce92663d334df9ecf5106f5c6/idna-2.6-py2.py3-none-any.whl#sha256=8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4
pulp2_dev: Best match: idna 2.6
pulp2_dev: Processing idna-2.6-py2.py3-none-any.whl
pulp2_dev: Installing idna-2.6-py2.py3-none-any.whl to /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages
pulp2_dev: Adding idna 2.6 to easy-install.pth file
pulp2_dev:
pulp2_dev: Installed /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/idna-2.6-py3.6.egg
pulp2_dev: Searching for chardet<3.1.0,>=3.0.2
pulp2_dev: Reading https://pypi.python.org/simple/chardet/
pulp2_dev: Downloading https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl#sha256=fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691
pulp2_dev: Best match: chardet 3.0.4
pulp2_dev: Processing chardet-3.0.4-py2.py3-none-any.whl
pulp2_dev: Installing chardet-3.0.4-py2.py3-none-any.whl to /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages
pulp2_dev: Adding chardet 3.0.4 to easy-install.pth file
pulp2_dev: Installing chardetect script to /home/vagrant/.virtualenvs/pulp-smash/bin
pulp2_dev:
pulp2_dev: Installed /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/chardet-3.0.4-py3.6.egg
pulp2_dev: Searching for certifi>=2017.4.17
pulp2_dev: Reading https://pypi.python.org/simple/certifi/
pulp2_dev: Downloading https://files.pythonhosted.org/packages/7c/e6/92ad559b7192d846975fc916b65f667c7b8c3a32bea7372340bfe9a15fa5/certifi-2018.4.16-py2.py3-none-any.whl#sha256=9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0
pulp2_dev: Best match: certifi 2018.4.16
pulp2_dev: Processing certifi-2018.4.16-py2.py3-none-any.whl
pulp2_dev: Installing certifi-2018.4.16-py2.py3-none-any.whl to /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages
pulp2_dev: Adding certifi 2018.4.16 to easy-install.pth file
pulp2_dev:
pulp2_dev: Installed /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/certifi-2018.4.16-py3.6.egg
pulp2_dev: Searching for pyparsing>=2.0.2
pulp2_dev: Reading https://pypi.python.org/simple/pyparsing/
pulp2_dev: Downloading https://files.pythonhosted.org/packages/6a/8a/718fd7d3458f9fab8e67186b00abdd345b639976bc7fb3ae722e1b026a50/pyparsing-2.2.0-py2.py3-none-any.whl#sha256=fee43f17a9c4087e7ed1605bd6df994c6173c1e977d7ade7b651292fab2bd010
pulp2_dev: Best match: pyparsing 2.2.0
pulp2_dev: Processing pyparsing-2.2.0-py2.py3-none-any.whl
pulp2_dev: Installing pyparsing-2.2.0-py2.py3-none-any.whl to /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages
pulp2_dev: Adding pyparsing 2.2.0 to easy-install.pth file
pulp2_dev:
pulp2_dev: Installed /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/pyparsing-2.2.0-py3.6.egg
pulp2_dev: Searching for six==1.11.0
pulp2_dev: Best match: six 1.11.0
pulp2_dev: Adding six 1.11.0 to easy-install.pth file
pulp2_dev:
pulp2_dev: Using /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages
pulp2_dev: Finished processing dependencies for pulp-smash==2018.4.12
pulp2_dev: /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/setuptools/dist.py:397: UserWarning: Normalizing '2018.04.12' to '2018.4.12'
pulp2_dev:   normalized_version,
pulp2_dev: ~/devel ~
```

## `name or service not known`

Notice the incorrect `host=` parameter in the stack-traces. `vagrant-setup.sh` is setting the [pulp_smash hostname parameter](https://github.com/PulpQE/pulp-smash/blob/master/pulp_smash/config.py#L286) as `https://$(hostname)` which is being interpreted as the hostname `https`.

### Proof: output from psmash run
```
======================================================================
ERROR: setUpModule (pulp_smash.tests.pulp2.rpm.api_v2.test_upload_publish)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/urllib3-1.22-py3.6.egg/urllib3/connection.py", line 141, in _new_conn
    (self.host, self.port), self.timeout, **extra_kw)
  File "/home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/urllib3-1.22-py3.6.egg/urllib3/util/connection.py", line 60, in create_connection
    for res in socket.getaddrinfo(host, port, family, socket.SOCK_STREAM):
  File "/usr/lib64/python3.6/socket.py", line 745, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
socket.gaierror: [Errno -2] Name or service not known

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/urllib3-1.22-py3.6.egg/urllib3/connectionpool.py", line 601, in urlopen
    chunked=chunked)
  File "/home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/urllib3-1.22-py3.6.egg/urllib3/connectionpool.py", line 346, in _make_request
    self._validate_conn(conn)
  File "/home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/urllib3-1.22-py3.6.egg/urllib3/connectionpool.py", line 850, in _validate_conn
    conn.connect()
  File "/home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/urllib3-1.22-py3.6.egg/urllib3/connection.py", line 284, in connect
    conn = self._new_conn()
  File "/home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/urllib3-1.22-py3.6.egg/urllib3/connection.py", line 150, in _new_conn
    self, "Failed to establish a new connection: %s" % e)
urllib3.exceptions.NewConnectionError: <urllib3.connection.VerifiedHTTPSConnection object at 0x7fb3444420f0>: Failed to establish a new connection: [Errno -2] Name or service not known

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/requests-2.18.4-py3.6.egg/requests/adapters.py", line 440, in send
    timeout=timeout
  File "/home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/urllib3-1.22-py3.6.egg/urllib3/connectionpool.py", line 639, in urlopen
    _stacktrace=sys.exc_info()[2])
  File "/home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/urllib3-1.22-py3.6.egg/urllib3/util/retry.py", line 388, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='https', port=443): Max retries exceeded with url: /pulp/api/v2/plugins/types/ (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x7fb3444420f0>: Failed to establish a new connection: [Errno -2] Name or service not known',))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/vagrant/devel/pulp-smash/pulp_smash/tests/pulp2/rpm/utils.py", line 16, in set_up_module
    pulp2_utils.require_unit_types({'rpm'})
  File "/home/vagrant/devel/pulp-smash/pulp_smash/tests/pulp2/utils.py", line 46, in require_unit_types
    missing_unit_types = required_unit_types - get_unit_types()
  File "/home/vagrant/devel/pulp-smash/pulp_smash/tests/pulp2/utils.py", line 27, in get_unit_types
    unit_types = api.Client(config.get_config()).get(PLUGIN_TYPES_PATH).json()
  File "/home/vagrant/devel/pulp-smash/pulp_smash/api.py", line 292, in get
    return self.request('GET', url, **kwargs)
  File "/home/vagrant/devel/pulp-smash/pulp_smash/api.py", line 349, in request
    requests.request(method, **request_kwargs),
  File "/home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/requests-2.18.4-py3.6.egg/requests/api.py", line 58, in request
    return session.request(method=method, url=url, **kwargs)
  File "/home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/requests-2.18.4-py3.6.egg/requests/sessions.py", line 508, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/requests-2.18.4-py3.6.egg/requests/sessions.py", line 618, in send
    r = adapter.send(request, **kwargs)
  File "/home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages/requests-2.18.4-py3.6.egg/requests/adapters.py", line 508, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='https', port=443): Max retries exceeded with url: /pulp/api/v2/plugins/types/ (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x7fb3444420f0>: Failed to establish a new connection: [Errno -2] Name or service not known',))
```

Note the hostname includes protocol.

```
(pulp-smash) [vagrant@pulp2 ~]$ pulp-smash settings show
{
  "pulp": {
    "auth": [
      "admin",
      "admin"
    ],
    "version": "2.15"
  },
  "systems": [
    {
      "hostname": "https://pulp2.dev",
      "roles": {
        "amqp broker": {
          "service": "qpidd"
        },
        "api": {
          "scheme": "https",
          "verify": false
        },
        "mongod": {},
        "pulp celerybeat": {},
        "pulp cli": {},
        "pulp resource manager": {},
        "pulp workers": {},
        "shell": {
          "transport": "local"
        },
        "squid": {}
      }
    }
  ]
}

```

## `getfattr: command not found`

Missing yum dependency. It's listed in the pulp-smash ansible role, but that's not applied by default. (And after reading said role, it should not.)

I found this issue while addressing PulpQE/pulp-smash#975.

```
$ (pulp-smash) [vagrant@pulp2 pulp-smash]$ py.test pulp_smash/tests/pulp2/platform/cli/test_selinux.py
_________________________________________________________________ FileLabelsTestCase.test_pulp_celery_fc _________________________________________________________________
 
self = <pulp_smash.tests.pulp2.platform.cli.test_selinux.FileLabelsTestCase testMethod=test_pulp_celery_fc>
 
    def test_pulp_celery_fc(self):
        """Test files listed in ``pulp-celery.fc``."""
        with self.subTest():
>           self._do_test('/usr/bin/celery', ':object_r:celery_exec_t:s0')
 
pulp_smash/tests/pulp2/platform/cli/test_selinux.py:162:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pulp_smash/tests/pulp2/platform/cli/test_selinux.py:138: in _do_test
    lines = self.client.run(cmd).stdout.splitlines()
pulp_smash/cli.py:227: in run
    return self.response_handler(completed_process)
pulp_smash/cli.py:51: in code_handler
    completed_proc.check_returncode()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
 
self = CompletedProcess(args=['sudo', 'getfattr', '--name=security.selinux', '/usr/bin/celery'], returncode=1, stdout='', stderr='sudo: getfattr: command not found\n')
 
    def check_returncode(self):
        """Raise an exception if ``returncode`` is non-zero.
 
            Raise :class:`pulp_smash.exceptions.CalledProcessError` if
            ``returncode`` is non-zero.
 
            Why not raise ``subprocess.CalledProcessError``? Because stdout and
            stderr are not included when str() is called on a CalledProcessError
            object. A typical message is::
 
                "Command '('ls', 'foo')' returned non-zero exit status 2"
 
            This information is valuable. One could still make
            ``subprocess.CalledProcessError`` work by overloading ``args``:
 
            >>> if isinstance(args, (str, bytes)):
            ...     custom_args = (args, stdout, stderr)
            ... else:
            ...     custom_args = tuple(args) + (stdout, stderr)
            >>> subprocess.CalledProcessError(args, returncode)
 
            But this seems like a hack.
 
            In addition, it's generally good for an application to raise expected
            exceptions from its own namespace, so as to better abstract away
            dependencies.
            """
        if self.returncode != 0:
            raise exceptions.CalledProcessError(
                self.args,
                self.returncode,
                self.stdout,
>               self.stderr,
            )
E           pulp_smash.exceptions.CalledProcessError: Command ['sudo', 'getfattr', '--name=security.selinux', '/usr/bin/celery'] returned non-zero exit status 1.
E
E           stdout:
E
E           stderr: sudo: getfattr: command not found
```

# Success!

It runs.

```
[vagrant@pulp2 ~]$ psmash
~ ~
flake8 . --ignore E501,F401 --exclude docs/_build
pylint -j 4 --reports=n --disable=I \
        docs/conf.py \
        pulp_smash \
        scripts/run_functional_tests.py \
        setup.py \
        tests
No config file found, using default configuration

------------------------------------
Your code has been rated at 10.00/10

python3 -m unittest discover --start-directory tests --top-level-directory .
..........................................................................................
----------------------------------------------------------------------
Ran 90 tests in 1.282s

OK
...
```

### Changed `vagrant up` log excerpt

Note the additional packages being installed. We leverage pip's ablity to install extras_requires packages via the "[X]" nomenclature. As far as I can tell, this is not possible with `python setup.py develop`. Setuptools documentation is well, setuptools. Enough said.

```
pulp2_dev: ~/devel ~
pulp2_dev: installing pulp-smash and its dependencies
pulp2_dev: ~/devel/pulp-smash ~/devel ~
pulp2_dev: Using base prefix '/usr'
pulp2_dev: New python executable in /home/vagrant/.virtualenvs/pulp-smash/bin/python3
pulp2_dev: Also creating executable in /home/vagrant/.virtualenvs/pulp-smash/bin/python
pulp2_dev: Installing setuptools, pip, wheel...
pulp2_dev: done.
pulp2_dev: Running virtualenv with interpreter /bin/python3
pulp2_dev: virtualenvwrapper.user_scripts creating /home/vagrant/.virtualenvs/pulp-smash/bin/predeactivate
pulp2_dev: virtualenvwrapper.user_scripts creating /home/vagrant/.virtualenvs/pulp-smash/bin/postdeactivate
pulp2_dev: virtualenvwrapper.user_scripts creating /home/vagrant/.virtualenvs/pulp-smash/bin/preactivate
pulp2_dev: virtualenvwrapper.user_scripts creating /home/vagrant/.virtualenvs/pulp-smash/bin/postactivate
pulp2_dev: virtualenvwrapper.user_scripts creating /home/vagrant/.virtualenvs/pulp-smash/bin/get_env_details
pulp2_dev: Setting project for pulp-smash to /home/vagrant/devel/pulp-smash
pulp2_dev: Could not open requirements file: [Errno 2] No such file or directory: 'requirements.txt'
pulp2_dev: Collecting pytest
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/ed/96/271c93f75212c06e2a7ec3e2fa8a9c90acee0a4838dc05bf379ea09aae31/pytest-3.5.0-py2.py3-none-any.whl (194kB)
pulp2_dev: Collecting pluggy<0.7,>=0.5 (from pytest)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/ba/65/ded3bc40bbf8d887f262f150fbe1ae6637765b5c9534bd55690ed2c0b0f7/pluggy-0.6.0-py3-none-any.whl
pulp2_dev: Requirement already satisfied: setuptools in /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages (from pytest) (39.0.1)
pulp2_dev: Collecting six>=1.10.0 (from pytest)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/67/4b/141a581104b1f6397bfa78ac9d43d8ad29a7ca43ea90a2d863fe3056e86a/six-1.11.0-py2.py3-none-any.whl
pulp2_dev: Collecting attrs>=17.4.0 (from pytest)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/b5/60/4e178c1e790fd60f1229a9b3cb2f8bc2f4cc6ff2c8838054c142c70b5adc/attrs-17.4.0-py2.py3-none-any.whl
pulp2_dev: Collecting py>=1.5.0 (from pytest)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/67/a5/f77982214dd4c8fd104b066f249adea2c49e25e8703d284382eb5e9ab35a/py-1.5.3-py2.py3-none-any.whl (84kB)
pulp2_dev: Collecting more-itertools>=4.0.0 (from pytest)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/7a/46/886917c6a4ce49dd3fff250c01c5abac5390d57992751384fe61befc4877/more_itertools-4.1.0-py3-none-any.whl (47kB)
pulp2_dev: Installing collected packages: pluggy, six, attrs, py, more-itertools, pytest
pulp2_dev: Successfully installed attrs-17.4.0 more-itertools-4.1.0 pluggy-0.6.0 py-1.5.3 pytest-3.5.0 six-1.11.0
pulp2_dev: Obtaining file:///home/vagrant/devel/pulp-smash
pulp2_dev: Collecting click (from pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/34/c1/8806f99713ddb993c5366c362b2f908f18269f8d792aff1abfd700775a77/click-6.7-py2.py3-none-any.whl (71kB)
pulp2_dev: Collecting jsonschema (from pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/77/de/47e35a97b2b05c2fadbec67d44cfcdcd09b8086951b331d82de90d2912da/jsonschema-2.6.0-py2.py3-none-any.whl
pulp2_dev: Collecting packaging (from pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/ad/c2/b500ea05d5f9f361a562f089fc91f77ed3b4783e13a08a3daf82069b1224/packaging-17.1-py2.py3-none-any.whl
pulp2_dev: Collecting plumbum (from pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/b2/05/7720109462d0bd60466e74076a38ca12068771da146bfd18a502726c9da8/plumbum-1.6.6-py2.py3-none-any.whl (111kB)
pulp2_dev: Collecting python-dateutil (from pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/0c/57/19f3a65bcf6d5be570ee8c35a5398496e10a0ddcbc95393b2d17f86aaaf8/python_dateutil-2.7.2-py2.py3-none-any.whl (212kB)
pulp2_dev: Collecting pyxdg (from pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/39/03/12eb9062f43adb94e30f366743cb5c83fd15fef026500cd4de42c7c12280/pyxdg-0.26-py2.py3-none-any.whl (40kB)
pulp2_dev: Collecting requests (from pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/49/df/50aa1999ab9bde74656c2919d9c0c085fd2b3775fd3eca826012bef76d8c/requests-2.18.4-py2.py3-none-any.whl (88kB)
pulp2_dev: Collecting flake8 (from pulp-smash==2018.4.12)
pulp2_dev:   Cache entry deserialization failed, entry ignored
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/b9/dc/14e9d94c770b8c4ef584e906c7583e74864786a58d47de101f2767d50c0b/flake8-3.5.0-py2.py3-none-any.whl (69kB)
pulp2_dev: Collecting flake8-docstrings (from pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/4e/ab/927dada116644e776c2668175d35545786f8a5120a9bdbfaaba2aab71687/flake8_docstrings-1.3.0-py2.py3-none-any.whl
pulp2_dev: Collecting flake8-quotes (from pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/83/ff/0461010959158bb7d197691c696f1a85b20f2d3eea7aa23f73a8d07f30f3/flake8-quotes-1.0.0.tar.gz
pulp2_dev: Collecting pydocstyle (from pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/43/8a/f1141af0c8406788a5c38ad5001d4163d903b5384a6517239d2ac42734c8/pydocstyle-2.1.1-py3-none-any.whl
pulp2_dev: Collecting pylint (from pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/8b/62/b2c07085dd7bb4b7e8bb813873421692c1157191e87234550a1c39dff232/pylint-1.8.4-py2.py3-none-any.whl (690kB)
pulp2_dev: Collecting astroid (from pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/f8/59/12a1d965bb99b595bfd72cc9a44863a0c00a2c05c38178f6139285bb00b5/astroid-1.6.3-py2.py3-none-any.whl (289kB)
pulp2_dev: Collecting coveralls (from pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/6f/c0/cd0b33454c0192cdd63360f8ac2a96a6132f01b34fa70524220c06fd4743/coveralls-1.3.0-py2.py3-none-any.whl
pulp2_dev: Collecting sphinx (from pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/24/0f/09869a479c626e860451a8b2cc7ed516abd93681b414e3aa9cddbe75f44b/Sphinx-1.7.3-py2.py3-none-any.whl (1.9MB)
pulp2_dev: Requirement already satisfied: wheel in /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages (from pulp-smash==2018.4.12) (0.31.0)
pulp2_dev: Collecting twine (from pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/65/ae/9cfdff186dd4812c59bad890435538858f13fe43dbe6923e0fb20f0adfc8/twine-1.11.0-py2.py3-none-any.whl
pulp2_dev: Requirement already satisfied: six in /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages (from packaging->pulp-smash==2018.4.12) (1.11.0)
pulp2_dev: Collecting pyparsing>=2.0.2 (from packaging->pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/6a/8a/718fd7d3458f9fab8e67186b00abdd345b639976bc7fb3ae722e1b026a50/pyparsing-2.2.0-py2.py3-none-any.whl (56kB)
pulp2_dev: Collecting urllib3<1.23,>=1.21.1 (from requests->pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/63/cb/6965947c13a94236f6d4b8223e21beb4d576dc72e8130bd7880f600839b8/urllib3-1.22-py2.py3-none-any.whl (132kB)
pulp2_dev: Collecting idna<2.7,>=2.5 (from requests->pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/27/cc/6dd9a3869f15c2edfab863b992838277279ce92663d334df9ecf5106f5c6/idna-2.6-py2.py3-none-any.whl (56kB)
pulp2_dev: Collecting certifi>=2017.4.17 (from requests->pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/7c/e6/92ad559b7192d846975fc916b65f667c7b8c3a32bea7372340bfe9a15fa5/certifi-2018.4.16-py2.py3-none-any.whl (150kB)
pulp2_dev: Collecting chardet<3.1.0,>=3.0.2 (from requests->pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl (133kB)
pulp2_dev: Collecting pycodestyle<2.4.0,>=2.0.0 (from flake8->pulp-smash==2018.4.12)
pulp2_dev:   Cache entry deserialization failed, entry ignored
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/e4/81/78fe51eb4038d1388b7217dd63770b0f428370207125047312886c923b26/pycodestyle-2.3.1-py2.py3-none-any.whl (45kB)
pulp2_dev: Collecting mccabe<0.7.0,>=0.6.0 (from flake8->pulp-smash==2018.4.12)
pulp2_dev:   Cache entry deserialization failed, entry ignored
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/87/89/479dc97e18549e21354893e4ee4ef36db1d237534982482c3681ee6e7b57/mccabe-0.6.1-py2.py3-none-any.whl
pulp2_dev: Collecting pyflakes<1.7.0,>=1.5.0 (from flake8->pulp-smash==2018.4.12)
pulp2_dev:   Cache entry deserialization failed, entry ignored
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/d7/40/733bcc64da3161ae4122c11e88269f276358ca29335468005cb0ee538665/pyflakes-1.6.0-py2.py3-none-any.whl (227kB)
pulp2_dev: Collecting flake8-polyfill (from flake8-docstrings->pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/86/b5/a43fed6fd0193585d17d6faa7b85317d4461f694aaed546098c69f856579/flake8_polyfill-1.0.2-py2.py3-none-any.whl
pulp2_dev: Collecting snowballstemmer (from pydocstyle->pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/d4/6c/8a935e2c7b54a37714656d753e4187ee0631988184ed50c0cf6476858566/snowballstemmer-1.2.1-py2.py3-none-any.whl (64kB)
pulp2_dev: Collecting isort>=4.2.5 (from pylint->pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/1f/2c/22eee714d7199ae0464beda6ad5fedec8fee6a2f7ffd1e8f1840928fe318/isort-4.3.4-py3-none-any.whl (45kB)
pulp2_dev: Collecting wrapt (from astroid->pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/a0/47/66897906448185fcb77fc3c2b1bc20ed0ecca81a0f2f88eda3fc5a34fc3d/wrapt-1.10.11.tar.gz
pulp2_dev: Collecting lazy-object-proxy (from astroid->pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/65/1f/2043ec33066e779905ed7e6580384425fdc7dc2ac64d6931060c75b0c5a3/lazy_object_proxy-1.3.1-cp36-cp36m-manylinux1_x86_64.whl (55kB)
pulp2_dev: Collecting coverage>=3.6 (from coveralls->pulp-smash==2018.4.12)
pulp2_dev:   Cache entry deserialization failed, entry ignored
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/3d/a0/b12090c40e0b8196b973962ec71c1c541a6c04af58ba5ad85683b3de251a/coverage-4.5.1-cp36-cp36m-manylinux1_x86_64.whl (202kB)
pulp2_dev: Collecting docopt>=0.6.1 (from coveralls->pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz
pulp2_dev: Collecting sphinxcontrib-websupport (from sphinx->pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/56/0f/3ee19ca5e5a1d9751cf4bbeb372d40a46421c4321fe55a4703ba66d0bafb/sphinxcontrib_websupport-1.0.1-py2.py3-none-any.whl
pulp2_dev: Collecting Pygments>=2.0 (from sphinx->pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/02/ee/b6e02dc6529e82b75bb06823ff7d005b141037cb1416b10c6f00fc419dca/Pygments-2.2.0-py2.py3-none-any.whl (841kB)
pulp2_dev: Collecting alabaster<0.8,>=0.7 (from sphinx->pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/2e/c3/9b7dcd8548cf2c00531763ba154e524af575e8f36701bacfe5bcadc67440/alabaster-0.7.10-py2.py3-none-any.whl
pulp2_dev: Requirement already satisfied: setuptools in /home/vagrant/.virtualenvs/pulp-smash/lib/python3.6/site-packages (from sphinx->pulp-smash==2018.4.12) (39.0.1)
pulp2_dev: Collecting imagesize (from sphinx->pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/e9/79/31cc1c2e0daf575f8fd2b581e2975e6a6938bd439581f766b79c50479521/imagesize-1.0.0-py2.py3-none-any.whl
pulp2_dev: Collecting Jinja2>=2.3 (from sphinx->pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/7f/ff/ae64bacdfc95f27a016a7bed8e8686763ba4d277a78ca76f32659220a731/Jinja2-2.10-py2.py3-none-any.whl (126kB)
pulp2_dev: Collecting docutils>=0.11 (from sphinx->pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/36/fa/08e9e6e0e3cbd1d362c3bbee8d01d0aedb2155c4ac112b19ef3cae8eed8d/docutils-0.14-py3-none-any.whl (543kB)
pulp2_dev: Collecting babel!=2.0,>=1.3 (from sphinx->pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/94/03/14e68ad12e771a79cf96792f7158d68a7b3d8c7b2badf39e9ef1f65b57d6/Babel-2.5.3-py2.py3-none-any.whl (6.8MB)
pulp2_dev: Collecting pkginfo>=1.4.2 (from twine->pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/a3/fe/f32a48d48f40a7209be9825fba2566cab92364787cf37de2e08300dd6ce7/pkginfo-1.4.2-py2.py3-none-any.whl
pulp2_dev: Collecting requests-toolbelt>=0.8.0 (from twine->pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/97/8a/d710f792d6f6ecc089c5e55b66e66c3f2f35516a1ede5a8f54c13350ffb0/requests_toolbelt-0.8.0-py2.py3-none-any.whl (54kB)
pulp2_dev: Collecting tqdm>=4.14 (from twine->pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/78/bc/de067ab2d700b91717dc5459d86a1877e2df31abfb90ab01a5a5a5ce30b4/tqdm-4.23.0-py2.py3-none-any.whl (42kB)
pulp2_dev: Collecting MarkupSafe>=0.23 (from Jinja2>=2.3->sphinx->pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz
pulp2_dev: Collecting pytz>=0a (from babel!=2.0,>=1.3->sphinx->pulp-smash==2018.4.12)
pulp2_dev:   Downloading https://files.pythonhosted.org/packages/dc/83/15f7833b70d3e067ca91467ca245bae0f6fe56ddc7451aa0dc5606b120f2/pytz-2018.4-py2.py3-none-any.whl (510kB)
pulp2_dev: Building wheels for collected packages: flake8-quotes, wrapt, docopt, MarkupSafe
pulp2_dev:   Running setup.py bdist_wheel for flake8-quotes: started
pulp2_dev:   Running setup.py bdist_wheel for flake8-quotes: finished with status 'done'
pulp2_dev:   Stored in directory: /home/vagrant/.cache/pip/wheels/8a/21/fa/534986265ebb1991d91e70556fe2abe8d439f3e31cee78a22a
pulp2_dev:   Running setup.py bdist_wheel for wrapt: started
pulp2_dev:   Running setup.py bdist_wheel for wrapt: finished with status 'done'
pulp2_dev:   Stored in directory: /home/vagrant/.cache/pip/wheels/48/5d/04/22361a593e70d23b1f7746d932802efe1f0e523376a74f321e
pulp2_dev:   Running setup.py bdist_wheel for docopt: started
pulp2_dev:   Running setup.py bdist_wheel for docopt: finished with status 'done'
pulp2_dev:   Stored in directory: /home/vagrant/.cache/pip/wheels/9b/04/dd/7daf4150b6d9b12949298737de9431a324d4b797ffd63f526e
pulp2_dev:   Running setup.py bdist_wheel for MarkupSafe: started
pulp2_dev:   Running setup.py bdist_wheel for MarkupSafe: finished with status 'done'
pulp2_dev:   Stored in directory: /home/vagrant/.cache/pip/wheels/33/56/20/ebe49a5c612fffe1c5a632146b16596f9e64676768661e4e46
pulp2_dev: Successfully built flake8-quotes wrapt docopt MarkupSafe
pulp2_dev: Installing collected packages: click, jsonschema, pyparsing, packaging, plumbum, python-dateutil, pyxdg, urllib3, idna, certifi, chardet, requests, pycodestyle, mccabe, pyflakes, flake8, flake8-polyfill, snowballstemmer, pydocstyle, flake8-docstrings, flake8-quotes, isort, wrapt, lazy-object-proxy, astroid, pylint, coverage, docopt, coveralls, sphinxcontrib-websupport, Pygments, alabaster, imagesize, MarkupSafe, Jinja2, docutils, pytz, babel, sphinx, pkginfo, requests-toolbelt, tqdm, twine, pulp-smash
pulp2_dev:   Running setup.py develop for pulp-smash
pulp2_dev: Successfully installed Jinja2-2.10 MarkupSafe-1.0 Pygments-2.2.0 alabaster-0.7.10 astroid-1.6.3 babel-2.5.3 certifi-2018.4.16 chardet-3.0.4 click-6.7 coverage-4.5.1 coveralls-1.3.0 docopt-0.6.2 docutils-0.14 flake8-3.5.0 flake8-docstrings-1.3.0 flake8-polyfill-1.0.2 flake8-quotes-1.0.0 idna-2.6 imagesize-1.0.0 isort-4.3.4 jsonschema-2.6.0 lazy-object-proxy-1.3.1 mccabe-0.6.1 packaging-17.1 pkginfo-1.4.2 plumbum-1.6.6 pulp-smash pycodestyle-2.3.1 pydocstyle-2.1.1 pyflakes-1.6.0 pylint-1.8.4 pyparsing-2.2.0 python-dateutil-2.7.2 pytz-2018.4 pyxdg-0.26 requests-2.18.4 requests-toolbelt-0.8.0 snowballstemmer-1.2.1 sphinx-1.7.3 sphinxcontrib-websupport-1.0.1 tqdm-4.23.0 twine-1.11.0 urllib3-1.22 wrapt-1.10.11
pulp2_dev: ~/devel ~
 ```