### PR TITLE
Require Ansible 2.4+

### DIFF
--- a/ansible/deploy-pulp3.yml
+++ b/ansible/deploy-pulp3.yml
@@ -3,14 +3,12 @@
 - hosts: all
   become: true
   pre_tasks:
-    - name: Require minimal Python and Ansible versions
+    - name: Require Ansible 2.4+
       assert:
         that:
-          - "ansible_python_version|version_compare('3.5.0', operator='ge')"
-          - "ansible_version.full|version_compare('2.3.2', operator='ge')"
+          - ansible_version.full|version_compare('2.4', operator='ge')
         msg: >
-          This playbook requires Python 3.5+ and Ansible 2.3.2+. If your package
-          manager ships an older version of Ansible, consider creating a
-          virtualenv and installing Ansible with pip.
+          This playbook requires Ansible 2.4+. Consider creating a virtualenv
+          and installing Ansible with pip.
   roles:
     - pulp3


### PR DESCRIPTION
Ansible 2.4 or newer is required to use the new `include_*` and
`import_*` statements. The ansible-pulp3 repository uses these
constructs.

Drop the check for Python 3.5+ on the target host. This allows this
playbook to be executed against distributions like RHEL 7, which ship
python 3.5+ via SCLs. This change has already been implemented in the
`pulp-from-source.yml` playbook, which helped in making a Jenkins job
that installs Pulp 3 from source on RHEL 7.

Also see: 2b8e3e3ddc61fcc43ee3e3498a18d6f65f3a2e2e
