### PR TITLE
Fix remaining deprecated uses of filters

### DIFF
--- a/ansible/deploy-pulp3.yml
+++ b/ansible/deploy-pulp3.yml
@@ -6,7 +6,7 @@
     - name: Require Ansible 2.4+
       assert:
         that:
-          - ansible_version.full|version_compare('2.4', operator='ge')
+          - ansible_version.full is version_compare('2.4', operator='ge')
         msg: >
           This playbook requires Ansible 2.4+. Consider creating a virtualenv
           and installing Ansible with pip.

--- a/ansible/pulp-from-source.yml
+++ b/ansible/pulp-from-source.yml
@@ -12,7 +12,7 @@
     - name: Require Ansible 2.4+
       assert:
         that:
-          - ansible_version.full|version_compare('2.4', operator='ge')
+          - ansible_version.full is version_compare('2.4', operator='ge')
         msg: >
           This playbook requires Ansible 2.4+. Consider creating a virtualenv
           and installing Ansible with pip.

--- a/ansible/roles/configure_rhel_7/tasks/main.yml
+++ b/ansible/roles/configure_rhel_7/tasks/main.yml
@@ -42,7 +42,7 @@
     tags:
       - skip_ansible_lint
 
-  when: result|changed
+  when: result is changed
   become: true
 
 - name: Install Python 3.6 SCL
@@ -61,7 +61,7 @@
 
 - name: Update yum's cache
   command: yum -y makecache
-  when: result|changed
+  when: result is changed
   become: true
   tags:
     - skip_ansible_lint

--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -77,7 +77,7 @@
       name: setuptools
       state: latest
       executable: '{{ pulp_scl_enable_python3 }}{{ pulp_venv }}/bin/pip'
-    when: result|changed
+    when: result is changed
     tags:
       - skip_ansible_lint
 


### PR DESCRIPTION
When writing a test using jinja tests, use jinja syntax, not filter
syntax.

See:
https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_2.5.html#jinja-tests-used-as-filters