### PR TITLE
Rename pulp selinux enabled flag

### DIFF
--- a/scripts/vagrant-setup.sh
+++ b/scripts/vagrant-setup.sh
@@ -63,7 +63,7 @@ if [ -d pulp-smash ]; then
   "pulp": {
     "auth": ["admin", "admin"],
     "version": "2.15",
-    "selinux_enable": true
+    "selinux enable": true
   },
   "systems": [
     {


### PR DESCRIPTION
Per PulpQE/pulp-smash#975.

The default behavior is to already have selinux tests enabled. This merely makes the default deploy of the config present it as a hint to the future.