### PR TITLE
Revert "Bump Fedora version"

### DIFF
--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -27,7 +27,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # to browse that repository a bit to find the latest successful Vagrant image. For example, at the
   # time of this writing, I could set this setting like this for the latest F24 image:
   # config.vm.box = "https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/CloudImages/x86_64/images/<imagename>.vagrant-libvirt.box"
-  config.vm.box = "fedora/28-cloud-base"
+  config.vm.box = "fedora/26-cloud-base"
 
   # Comment out if you don't want Vagrant to add and remove entries from /etc/hosts for each VM.
   # requires the vagrant-hostmanager plugin to be installed


### PR DESCRIPTION
Reverts pulp/devel#160

Pulp 2 broken on Fedora 28 due to missing ```python-django```, ```python-rhsm``` packages.