### PR TITLE
Update packages to match fedora repo

### DIFF
--- a/ansible/library/pulp_facts.py
+++ b/ansible/library/pulp_facts.py
@@ -19,7 +19,19 @@ pipe = subprocess.Popen('/usr/sbin/getenforce', stdout=subprocess.PIPE,
 stdout, stderr = pipe.communicate()
 selinux_enabled = 'Enforcing' in stdout
 
-rpm_dependency_list = list(['nss-tools', 'pygobject3', 'deltarpm', 'kobo', 'puppet', 'python2-lxml', 'python-ldap', 'crontabs', 'httpd', 'systemd', 'git', 'mod_ssl', 'python-pycurl', 'python-oauth2', 'policycoreutils-python', 'python-isodate', 'python-nectar', 'libselinux-python', 'python-blinker', 'python-iniparse', 'python-flask', 'mod_wsgi', 'repoview', 'python-mongoengine', 'python-setuptools', 'python-django', 'python', 'python-deltarpm', 'python-rhsm', 'rsync', 'pyliblzma', 'python-httplib2', 'm2crypto', 'genisoimage', 'createrepo', 'python-twisted', 'python-qpid', 'mod_xsendfile', 'python-twine', 'selinux-policy', 'python-pymongo', 'python-gnupg', 'gofer', 'ostree', 'python-semantic_version', 'openssl', 'acl', 'createrepo_c', 'yum', 'python-okaara', 'gnupg', 'python-gofer', 'python-celery'])
+rpm_dependency_list = list(['nss-tools', 'pygobject3', 'deltarpm', 'kobo', 'puppet',
+                            'python2-lxml', 'python-ldap', 'crontabs', 'httpd', 'systemd', 'git',
+                            'mod_ssl', 'python-pycurl', 'python-oauth2', 'policycoreutils-python',
+                            'python-isodate', 'python-nectar', 'libselinux-python',
+                            'python-blinker', 'python-iniparse', 'python-flask', 'mod_wsgi',
+                            'repoview', 'python-mongoengine', 'python-setuptools',
+                            'python2-django1.11', 'python', 'python-deltarpm',
+                            'rsync', 'pyliblzma', 'python-httplib2', 'm2crypto', 'genisoimage',
+                            'createrepo', 'python-twisted', 'python-qpid', 'mod_xsendfile',
+                            'python-twine', 'selinux-policy', 'python-pymongo', 'python-gnupg',
+                            'gofer', 'ostree', 'python-semantic_version', 'openssl', 'acl',
+                            'createrepo_c', 'yum', 'python-okaara', 'gnupg', 'python-gofer',
+                            'python-celery'])
 
 # Build the facts for Ansible
 facts = {

--- a/scripts/bootstrap-ansible.sh
+++ b/scripts/bootstrap-ansible.sh
@@ -3,3 +3,7 @@
 # minimal bootstrapping before kicking off ansible:
 #  install only what ansible needs to survive, or doesn't know how to do
 sudo dnf -y install python2 python2-dnf libselinux-python
+
+# Install rhsm and its deps from url since they aren't in fedora yet.
+sudo dnf -y install https://kojipkgs.fedoraproject.org//packages/subscription-manager/1.21.4/3.fc29/x86_64/subscription-manager-rhsm-certificates-1.21.4-3.fc29.x86_64.rpm
+sudo dnf -y install https://kojipkgs.fedoraproject.org//packages/subscription-manager/1.21.4/3.fc29/x86_64/python2-subscription-manager-rhsm-1.21.4-3.fc29.x86_64.rpm


### PR DESCRIPTION
python-django -> python2-django1.11

python-rhsm was removed, and has not yet been replaced in the upstream
repo. Instead, I added url installs to the pre-script.