### PR TITLE
Make Travis check syntax of pulp-from-source.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ python:
 install:
   - pip install ansible-lint
 script:
+  - ansible-playbook ansible/pulp-from-source.yml --syntax-check
   - ansible-lint ansible/pulp-from-source.yml
 cache: pip


### PR DESCRIPTION
Ansible-lint checks for code smells, not syntax issues. Thus, it's
useful to call both ansible-lint and Ansible's syntax checker.