### PR TITLE
Small devel fixes

### DIFF
--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -81,11 +81,6 @@
     tags:
       - skip_ansible_lint
 
-  - name: Install custom RQ
-    pip:
-      name: 'git+https://github.com/rq/rq.git@3133d94b58e59cb86e8f4677492d48b2addcf5f8'
-      executable: '{{ pulp_scl_enable_python3 }}{{ pulp_venv }}/bin/pip'
-
   - name: Install Pulp Platform packages
     pip:
       name: '{{ pulp_devel_dir }}/pulp/{{ item }}'

--- a/ansible/roles/dev_tools/tasks/main.yml
+++ b/ansible/roles/dev_tools/tasks/main.yml
@@ -7,6 +7,7 @@
       name: vim-enhanced
       state: present
     register: result
+    ignore_errors: yes
 
   - name: Upgrade vim-minimal if installing vim-enhanced failed
     package:


### PR DESCRIPTION
* Install jemalloc-devel which Redis needs when starting on f28 for some
  reason.
* Remove the custom RQ version we were using
* Skip errors on a place that was halting the playbook even though it
  has correct error checking.