### PR TITLE
Fix pulp_deb dependencies

### DIFF
--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -27,7 +27,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # to browse that repository a bit to find the latest successful Vagrant image. For example, at the
   # time of this writing, I could set this setting like this for the latest F24 image:
   # config.vm.box = "https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/CloudImages/x86_64/images/<imagename>.vagrant-libvirt.box"
-  config.vm.box = "fedora/28-cloud-base"
+  config.vm.box = "fedora/27-cloud-base"
 
   # Comment out if you don't want Vagrant to add and remove entries from /etc/hosts for each VM.
   # requires the vagrant-hostmanager plugin to be installed

--- a/ansible/library/pulp_facts.py
+++ b/ansible/library/pulp_facts.py
@@ -25,13 +25,13 @@ rpm_dependency_list = list(['nss-tools', 'pygobject3', 'deltarpm', 'kobo', 'pupp
                             'python-isodate', 'python-nectar', 'libselinux-python',
                             'python-blinker', 'python-iniparse', 'python-flask', 'mod_wsgi',
                             'repoview', 'python-mongoengine', 'python-setuptools',
-                            'python2-django1.11', 'python', 'python-deltarpm',
+                            'python2-django', 'python', 'python-deltarpm',
                             'rsync', 'pyliblzma', 'python-httplib2', 'm2crypto', 'genisoimage',
                             'createrepo', 'python-twisted', 'python-qpid', 'mod_xsendfile',
                             'python-twine', 'selinux-policy', 'python-pymongo', 'python-gnupg',
                             'gofer', 'ostree', 'python-semantic_version', 'openssl', 'acl',
                             'createrepo_c', 'yum', 'python-okaara', 'gnupg', 'python-gofer',
-                            'python-celery'])
+                            'python-celery', 'python-debian', 'python2-debpkgr', 'python2-gnupg'])
 
 # Build the facts for Ansible
 facts = {


### PR DESCRIPTION
This goes hand in hand with:
https://github.com/pulp/pulp_deb/pull/45

Together they make spinning up the pulp2_dev vagrant box with pulp_deb possible again.