### PR TITLE
Revamp how ansible does migrations

### DIFF
--- a/ansible/pulp-from-source.yml
+++ b/ansible/pulp-from-source.yml
@@ -24,6 +24,7 @@
     - dev
     - {role: plugin, plugin_name: 'pulp_file', app_label: 'pulp_file'}
     # - {role: plugin, plugin_name: 'pulp_python', app_label: 'pulp_python'}
+    - django_db
     - systemd
     - role: dev_tools
       when: ansible_distribution == 'Fedora'

--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -173,8 +173,7 @@
 
   become: true
 
-- name: Create and run migrations for {{ pulp_app }}
-  include_role:
-    name: django_db
-  vars:
-    app_label: pulp_app
+- name: Create migrations for pulp_app
+  command: >
+    {{ pulp_scl_enable_python3 }}
+    {{ pulp_venv }}/bin/pulp-manager makemigrations pulp_app

--- a/ansible/roles/django_db/tasks/main.yml
+++ b/ansible/roles/django_db/tasks/main.yml
@@ -11,26 +11,17 @@
   register: result
   failed_when: "result is failed and 'Could not find the requested service' not in result.msg"
 
-
-- block:
-
-  - name: Make migrations for {{ app_label }}
-    command: >
-      {{ pulp_scl_enable_python3 }}
-      {{ pulp_venv }}/bin/pulp-manager makemigrations {{ app_label }}
-
-  - name: Run all migrations
-    command: >
-      {{ pulp_scl_enable_python3 }}
-      {{ pulp_venv }}/bin/pulp-manager {{ item }}
-    with_items:
-      - reset_db --noinput
-      - migrate auth --noinput
-      - migrate --noinput
-      - reset-admin-password --password admin
-
-    become: true
-    become_user: '{{ pulp_user }}'
+- name: Run all migrations
+  command: >
+    {{ pulp_scl_enable_python3 }}
+    {{ pulp_venv }}/bin/pulp-manager {{ item }}
+  with_items:
+    - reset_db --noinput
+    - migrate auth --noinput
+    - migrate --noinput
+    - reset-admin-password --password admin
+  become: true
+  become_user: '{{ pulp_user }}'
 
 
 - name: Start Pulp services

--- a/ansible/roles/django_db/tasks/main.yml
+++ b/ansible/roles/django_db/tasks/main.yml
@@ -1,3 +1,17 @@
+- name: Stop Pulp services
+  systemd:
+    name: '{{ item }}'
+    state: stopped
+  with_items:
+    - pulp_resource_manager
+    - pulp_worker@1
+    - pulp_worker@2
+  become: true
+  # the services might not have been installed yet
+  register: result
+  failed_when: "result is failed and 'Could not find the requested service' not in result.msg"
+
+
 - block:
 
   - name: Make migrations for {{ app_label }}
@@ -15,5 +29,19 @@
       - migrate --noinput
       - reset-admin-password --password admin
 
+    become: true
+    become_user: '{{ pulp_user }}'
+
+
+- name: Start Pulp services
+  systemd:
+    name: '{{ item }}'
+    state: started
+  with_items:
+    - pulp_resource_manager
+    - pulp_worker@1
+    - pulp_worker@2
   become: true
-  become_user: '{{ pulp_user }}'
+  # the services might not have been installed yet
+  register: result
+  failed_when: "result is failed and 'Could not find the requested service' not in result.msg"

--- a/ansible/roles/plugin/tasks/main.yml
+++ b/ansible/roles/plugin/tasks/main.yml
@@ -19,10 +19,9 @@
     become: true
     become_user: '{{ pulp_user }}'
 
-  # Variables in the current context are inherited by included roles. Thus, this
-  # role implicitly gets the app_label variable that it needs.
-  - name: Run migrations for {{ app_label }}
-    include_role:
-      name: django_db
+  - name: Make migrations for {{ app_label }}
+    command: >
+      {{ pulp_scl_enable_python3 }}
+      {{ pulp_venv }}/bin/pulp-manager makemigrations {{ app_label }}
 
   when: repo_path.stat.isdir is defined and repo_path.stat.isdir


### PR DESCRIPTION
Problem 1:  Re-running the ansible playbook on a box with an existing Pulp installation fails because the workers have active database connections, therefore it fails when attempting to reset the db.

Problem 2:  The ```django_db``` role is run for every single plugin, resetting the database and running the migrations over and over.  Apart from being inefficient, this seems to occasionally cause problems: https://pulp.plan.io/issues/3739

* Stop the systemd services prior to doing db reset / migration steps, and restart them after.  If it can't find the services because they haven't been installed yet, ignore them.
* Let the ```plugin``` role worry about *making* the migrations, and the ```django_db``` role worry about running them.  Only run ```django_db``` role once.
