### PR TITLE
Create permissions for pulp_app as root

### DIFF
--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -171,9 +171,9 @@
       group: '{{ pulp_user }}'
       mode: 0755
 
-  become: true
+  - name: Create migrations for pulp_app
+    command: >
+      {{ pulp_scl_enable_python3 }}
+      {{ pulp_venv }}/bin/pulp-manager makemigrations pulp_app
 
-- name: Create migrations for pulp_app
-  command: >
-    {{ pulp_scl_enable_python3 }}
-    {{ pulp_venv }}/bin/pulp-manager makemigrations pulp_app
+  become: true


### PR DESCRIPTION
When ansible executes tasks on a remote system, it executes those tasks
as the user it has logged in as. This behaviour can be overridden by
specifying task arguments such as `become: true`.

When Pulp 3 is being installed, migrations must be created for each of
the Django applications that comprise Pulp 3. When migrations are
created for the `pulp_app`, a permission denial occurs, because they are
being created as the default Ansible user. Fix this error by creating
migrations for `pulp_app` as root.

See: 4aa6fd29d8fa422ee01b475f387557a9a534f488