### PR TITLE
usermod vagrant with host user euid

### DIFF
--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -90,10 +90,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
 
     pulp3_dev.vm.provider :docker do |d, override|
+
+        uid = Process.euid
+        gid = Process.egid
+
         override.vm.box = nil
         # Based on fedora official image, with vagrant's needs met:
         # https://github.com/rohanpm/docker-fedora-vagrant
-        d.image = 'rohanpm/fedora-vagrant:latest'
+        # plugins/providers/docker/action/login.rb
+        d.build_dir = 'docker/'
+        d.build_args = ["--build-arg=USER_EUID=#{uid}", "--build-arg=USER_EGID=#{gid}"]
+          
 
         # use ssh for the sake of ansible
         d.has_ssh = true
@@ -109,38 +116,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             # Let the synced folders use docker's native mechanism
             # (bind mounts) instead of NFS
             override.vm.synced_folder host_path, guest_path, type: nil
-        end
-
-        # Reset the UID and GID of the vagrant user in the container equal to the
-        # UID/GID on the host.  This makes it much easier to deal with the
-        # permissions on shared directories.
-        #
-        # This is only needed for docker, so it's declared here in the docker
-        # provider.
-        #
-        # This is a shell provisioner because it's impractical to apply it using
-        # ansible due to peculiar requirements: you cannot 'usermod' a user if that
-        # user has any processes currently running - including the ssh session that
-        # vagrant itself uses to connect to the container.
-        override.vm.provision 'reset-user', :type => 'shell' do |shell|
-          uid = Process.euid
-          gid = Process.egid
-          reset_cmd = "/vagrant/scripts/vagrant-reset-user.sh #{uid} #{gid}"
-
-          shell.inline = <<-END_SCRIPT.gsub(/\s+/, ' ').strip
-            nohup sudo /bin/sh -c '
-              if ! #{reset_cmd}; then
-                wall "About to kill all vagrant processes for UID reassign!";
-                sleep 2;
-                pkill -TERM -u vagrant;
-                sleep 1;
-                pkill -KILL -u vagrant;
-                #{reset_cmd};
-              fi
-            ' >/tmp/reset-user.log 2>&1 &
-          END_SCRIPT
-
-          shell.privileged = false
         end
     end
   end

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,8 @@
+FROM rohanpm/fedora-vagrant:latest
+
+ARG USER_EUID=1001
+ARG USER_EGID=1001
+
+RUN /sbin/usermod -u ${USER_EUID} vagrant
+RUN /sbin/groupmod -g ${USER_EGID} vagrant
+RUN /bin/chown -R vagrant:vagrant /home/vagrant


### PR DESCRIPTION
The vagrant user is created with a default user EUID/EGID[1]
This prevets the RW access if vagrant user EUID isn't the same as the host user EUID.

Since the uid of a user can't be changed while it has any running processes (ssh) ansible can't be used to update the euid.
The patch introduces Dockerfile that modifies the vagrant EUID/EGID build-time.

Closes: #176
[1] https://github.com/rohanpm/docker-fedora-vagrant/blob/master/Dockerfile#L30