### PR TITLE
RFC: Install plugins in dev-environment if available

### DIFF
--- a/ansible/pulp-from-source.yml
+++ b/ansible/pulp-from-source.yml
@@ -22,11 +22,7 @@
     - db
     - redis
     - dev
-    - {role: plugin, plugin_name: 'pulp_file', app_label: 'pulp_file'}
-    # - {role: plugin, plugin_name: 'pulp_python', app_label: 'pulp_python'}
-    # - {role: plugin, plugin_name: 'pulp_ansible', app_label: 'pulp_ansible'}
-    # - {role: plugin, plugin_name: 'pulp_docker', app_label: 'pulp_docker'}
-    # - {role: plugin, plugin_name: 'pulp_rpm', app_label: 'pulp_rpm'}
+    - plugin
     - django_db
     - systemd
     - role: dev_tools

--- a/ansible/roles/plugin/tasks/install_plugin.yml
+++ b/ansible/roles/plugin/tasks/install_plugin.yml
@@ -1,0 +1,27 @@
+- name: Get information about {{ pulp_devel_dir }}/{{ plugin_name }}
+  stat:
+    path: '{{ pulp_devel_dir }}/{{ plugin_name }}'
+  register: repo_path
+  become: true
+  become_user: '{{ pulp_user }}'
+
+- debug:
+    msg: '{{ pulp_devel_dir }}/{{ plugin_name }} does not exist, skipping!'
+  when: repo_path.stat.isdir is not defined or not repo_path.stat.isdir
+
+- block:
+
+  - name: Install plugin packages into core Pulp Python environment
+    pip:
+      name: '{{ pulp_devel_dir }}/{{ plugin_name }}'
+      extra_args: '-e'
+      executable: '{{ pulp_scl_enable_python3 }}{{ pulp_venv }}/bin/pip'
+    become: true
+    become_user: '{{ pulp_user }}'
+
+  - name: Make migrations for {{ app_label }}
+    command: >
+      {{ pulp_scl_enable_python3 }}
+      {{ pulp_venv }}/bin/pulp-manager makemigrations {{ app_label }}
+
+  when: repo_path.stat.isdir is defined and repo_path.stat.isdir

--- a/ansible/roles/plugin/tasks/main.yml
+++ b/ansible/roles/plugin/tasks/main.yml
@@ -1,27 +1,27 @@
-- name: Get information about {{ pulp_devel_dir }}/{{ plugin_name }}
-  stat:
-    path: '{{ pulp_devel_dir }}/{{ plugin_name }}'
-  register: repo_path
-  become: true
-  become_user: '{{ pulp_user }}'
+---
+- name: Look for plugin directories
+  local_action:
+    module: find
+    paths: "{{ playbook_dir }}/../../"
+    file_type: directory
+    patterns: "pulp_*"
+  register: plugin_dirs
+- name: Look for setup.py in plugin directories
+  local_action:
+    module: find
+    paths: "{{ item }}"
+    file_type: file
+    patterns: "setup.py"
+  with_items: "{{ plugin_dirs.files | map(attribute='path') | list }}"
+  register: plugin_setups
+- name: Set plugins fact
+  set_fact:
+    plugins: "{{ plugin_setups.results | map(attribute='files') | flatten | map(attribute='path') | map('dirname') | map('basename') | list }}"
 
-- debug:
-    msg: '{{ pulp_devel_dir }}/{{ plugin_name }} does not exist, skipping!'
-  when: repo_path.stat.isdir is not defined or not repo_path.stat.isdir
-
-- block:
-
-  - name: Install plugin packages into core Pulp Python environment
-    pip:
-      name: '{{ pulp_devel_dir }}/{{ plugin_name }}'
-      extra_args: '-e'
-      executable: '{{ pulp_scl_enable_python3 }}{{ pulp_venv }}/bin/pip'
-    become: true
-    become_user: '{{ pulp_user }}'
-
-  - name: Make migrations for {{ app_label }}
-    command: >
-      {{ pulp_scl_enable_python3 }}
-      {{ pulp_venv }}/bin/pulp-manager makemigrations {{ app_label }}
-
-  when: repo_path.stat.isdir is defined and repo_path.stat.isdir
+- name: Install plugins
+  include_tasks: install_plugin.yml
+  vars:
+    plugin_name: '{{ item }}'
+    app_label: '{{ item }}'
+  with_items: '{{ plugins }}'
+...


### PR DESCRIPTION
I am not sure, whether those playbooks are used elsewhere, but if you want to mimic the way, the vagrant dev environment included the pulp plugins, this might be the way.