### PR TITLE
OSX Vagrantfile

### DIFF
--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -91,6 +91,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     pulp3_dev.vm.provider :docker do |d, override|
 
+        require 'rbconfig'
+        os = RbConfig::CONFIG['host_os'].downcase
+
         uid = Process.euid
         gid = Process.egid
 
@@ -99,8 +102,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         # https://github.com/rohanpm/docker-fedora-vagrant
         # plugins/providers/docker/action/login.rb
         d.build_dir = 'docker/'
-        d.build_args = ["--build-arg=USER_EUID=#{uid}", "--build-arg=USER_EGID=#{gid}"]
-          
+        d.build_args = ["--build-arg=USER_EUID=#{uid}"]
+        unless os.include? "darwin" then
+            d.build_args.push("--build-arg=USER_EGID=#{gid}")
+        end
 
         # use ssh for the sake of ansible
         d.has_ssh = true

--- a/ansible/roles/django_db/tasks/main.yml
+++ b/ansible/roles/django_db/tasks/main.yml
@@ -22,6 +22,8 @@
     - reset-admin-password --password admin
   become: true
   become_user: '{{ pulp_user }}'
+  tags:
+    - skip_ansible_lint
 
 
 - name: Start Pulp services


### PR DESCRIPTION
- don't use GID on OSX as it fails provision
- fix ansible-lint in travis by ignoring ANSIBLE0012 in djangodb migration task

Signed-off-by: Pavel Picka <ppicka@redhat.com>