### PR TITLE
The common package was removed

### DIFF
--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -87,7 +87,6 @@
       extra_args: '-e'
       executable: '{{ pulp_scl_enable_python3 }}{{ pulp_venv }}/bin/pip'
     with_items:
-      - common
       - pulpcore
       - plugin
 

--- a/ansible/roles/pulp-user/templates/alias.bashrc
+++ b/ansible/roles/pulp-user/templates/alias.bashrc
@@ -79,7 +79,7 @@ ptest() {
     python manage.py makemigrations pulp_file
     # Auth migrations must be run before pulpcore to generate schema that the User model relates to.
     python manage.py migrate auth --noinput
-    python manage.py test pulpcore/ common/
+    python manage.py test pulpcore/
 }
 _ptest_help="Run tests for pulp and all installed plugins/services"
 


### PR DESCRIPTION
pulpcore.common was removed and now is just part of the pulpcore
package. As such the install fails now. This removes that from the dev
install so it can start working again.

https://pulp.plan.io/issues/3652
re: #3652