### PR TITLE
Fix the name of the django package to install

### DIFF
--- a/ansible/library/pulp_facts.py
+++ b/ansible/library/pulp_facts.py
@@ -31,7 +31,7 @@ rpm_dependency_list = list(['acl', 'createrepo', 'createrepo_c', 'crontabs',
                             'python-nectar', 'python-oauth2', 'python-okaara', 'python-pycurl',
                             'python-pymongo', 'python-qpid', 'python-semantic_version',
                             'python-setuptools', 'python-twine', 'python-twisted',
-                            'python2-debpkgr', 'python2-django1.11', 'python2-gnupg', 'python2-lxml',
+                            'python2-debpkgr', 'python2-django', 'python2-gnupg', 'python2-lxml',
                             'python2-solv', 'repoview', 'rsync', 'selinux-policy', 'systemd',
                             'yum'])
 


### PR DESCRIPTION
The Pulp rpm deps include python2-django1.11 which can't be installed.
Replacing with python2-django allows installation of
  python2-django-1.10.8-1.fc26.noarch

Fixes: #188