### PR TITLE
Bump Docker to use Fedora latest

### DIFF
--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -96,10 +96,22 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
 
     pulp2_dev.vm.provider :docker do |d, override|
+
+        require 'rbconfig'
+        os = RbConfig::CONFIG['host_os'].downcase
+
+        uid = Process.euid
+        gid = Process.egid
+
         override.vm.box = nil
         # Based on fedora official image, with vagrant's needs met:
         # https://github.com/rohanpm/docker-fedora-vagrant
-        d.image = 'rohanpm/fedora-vagrant:26'
+        # plugins/providers/docker/action/login.rb
+        d.build_dir = 'docker/'
+        d.build_args = ["--build-arg=USER_EUID=#{uid}"]
+        unless os.include? "darwin" then
+            d.build_args.push("--build-arg=USER_EGID=#{gid}")
+        end
 
         # use ssh for the sake of ansible
         d.has_ssh = true
@@ -114,38 +126,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             # Let the synced folders use docker's native mechanism
             # (bind mounts) instead of NFS
             override.vm.synced_folder host_path, guest_path, type: nil
-        end
-
-        # Reset the UID and GID of the vagrant user in the container equal to the
-        # UID/GID on the host.  This makes it much easier to deal with the
-        # permissions on shared directories.
-        #
-        # This is only needed for docker, so it's declared here in the docker
-        # provider.
-        #
-        # This is a shell provisioner because it's impractical to apply it using
-        # ansible due to peculiar requirements: you cannot 'usermod' a user if that
-        # user has any processes currently running - including the ssh session that
-        # vagrant itself uses to connect to the container.
-        override.vm.provision 'reset-user', :type => 'shell' do |shell|
-          uid = Process.euid
-          gid = Process.egid
-          reset_cmd = "/vagrant/scripts/vagrant-reset-user.sh #{uid} #{gid}"
-
-          shell.inline = <<-END_SCRIPT.gsub(/\s+/, ' ').strip
-            nohup sudo /bin/sh -c '
-              if ! #{reset_cmd}; then
-                wall "About to kill all vagrant processes for UID reassign!";
-                sleep 2;
-                pkill -TERM -u vagrant;
-                sleep 1;
-                pkill -KILL -u vagrant;
-                #{reset_cmd};
-              fi
-            ' >/tmp/reset-user.log 2>&1 &
-          END_SCRIPT
-
-          shell.privileged = false
         end
     end
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,61 @@
+# all credit to https://raw.githubusercontent.com/rohanpm/docker-fedora-vagrant/master/Dockerfile
+FROM fedora:latest
+
+ARG USER_EUID=1001
+ARG USER_EGID=1001
+
+# This image should be kept to the minimal requirements for vagrant
+# to be able to ssh into the container and run provisioners.
+#
+# openssh-server: let "vagrant ssh" work
+# openssh-clients: let scp work
+# sudo: for vagrant user to elevate privileges
+# passwd: to set password for vagrant user
+
+RUN dnf -y install \
+ openssh-server \
+ openssh-clients \
+ sudo \
+ passwd \
+ && dnf clean all
+
+# Disable unneeded services
+RUN ["/usr/bin/rm", "-f", \
+     "/etc/systemd/system/basic.target.wants/dnf-makecache.timer", \
+     "/etc/systemd/system/getty.target.wants/getty@tty1.service"]
+
+# Disable any getty spawning
+RUN ["/bin/sh", "-c", "echo -e NAutoVTs=0\\\\nReserveVT=0 >> /etc/systemd/logind.conf"]
+
+# These changes are explained here:
+# https://www.vagrantup.com/docs/boxes/base.html
+
+# Add a user named vagrant
+RUN adduser vagrant
+
+# Let vagrant have passwordless sudo
+RUN echo 'vagrant ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+
+# Do not require a tty
+RUN sed -r -e 's|^Defaults.*requiretty|#\0|' -i /etc/sudoers
+
+# Make ssh connect faster
+RUN echo 'UseDNS no' >> /etc/ssh/sshd_config
+
+# Set password to 'vagrant'
+RUN echo vagrant | passwd --stdin vagrant
+
+# Set up ssh key
+USER vagrant
+RUN mkdir /home/vagrant/.ssh
+RUN chmod og-rx /home/vagrant/.ssh
+RUN ["/bin/sh", "-c", "echo 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key' > /home/vagrant/.ssh/authorized_keys"]
+
+USER root
+VOLUME /var/log
+ENV container=docker
+RUN /sbin/usermod -u ${USER_EUID} vagrant
+RUN /sbin/groupmod -g ${USER_EGID} vagrant
+RUN /bin/chown -R vagrant:vagrant /home/vagrant
+
+CMD ["/sbin/init"]


### PR DESCRIPTION
There hasn't been much activity on the origin of our Docker image
  https://github.com/rohanpm/docker-fedora-vagrant
so I'm importing that Dockerfile locally for us to maintain

Fixes: #188