### PR TITLE
Add a temporary? role for createrepo_c build dependencies

### DIFF
--- a/ansible/pulp-from-source.yml
+++ b/ansible/pulp-from-source.yml
@@ -21,6 +21,7 @@
     - pulp-user
     - db
     - redis
+    - createrepo_c
     - dev
     - plugin
     - django_db

--- a/ansible/roles/createrepo_c/tasks/main.yml
+++ b/ansible/roles/createrepo_c/tasks/main.yml
@@ -1,0 +1,20 @@
+- name: Install createrepo_c build dependencies
+  become: true
+  package:
+    name:
+      - gcc
+      - make
+      - cmake
+      - bzip2-devel
+      - expat-devel
+      - file-devel
+      - glib2-devel
+      - libcurl-devel
+      - libxml2-devel
+      - python3-devel
+      - rpm-devel
+      - openssl-devel
+      - sqlite-devel
+      - xz-devel
+      - zlib-devel
+    state: present


### PR DESCRIPTION
Avoids provisioning failure when pulp_rpm is one of the plugins to be installed.