### PR TITLE
dev-env: downgrade to Fedora 28 for docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # all credit to https://raw.githubusercontent.com/rohanpm/docker-fedora-vagrant/master/Dockerfile
-FROM fedora:latest
+FROM fedora:28
 
 ARG USER_EUID=1001
 ARG USER_EGID=1001


### PR DESCRIPTION
Fedora >= 29 can't work with pulp_rpm 2-master.

If you have a look here you can see that, starting from F29,
createrepo_c obsoletes createrepo:

https://src.fedoraproject.org/rpms/createrepo_c/c/1f5be3855226d83e9918bbeff15429366d3dfc27?branch=f29

This prevents installing both createrepo_c and createrepo
at the same time.

Meanwhile, pulp_rpm depends on both of them at the same time.
It uses "from createrepo import yumbased" which only exists
in createrepo, and it uses createrepo_c command which only
exists in createrepo_c. Hence pulp_rpm can't be used or
developed on Fedora >= 29 at the moment.

See also that the libvirt dev env uses Fedora 28.
It would be good for the libvirt and docker providers to stick with
the same Fedora version.