### PR TITLE
Fix docker dev env provision

### DIFF
--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -73,7 +73,7 @@
           - selinux-policy-devel
           - telnet
           - tito
-          - yum-utils
+          - dnf-utils
           - zlib-devel
 
 - name: Install gofer

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # all credit to https://raw.githubusercontent.com/rohanpm/docker-fedora-vagrant/master/Dockerfile
-FROM fedora:latest
+FROM fedora:28
 
 ARG USER_EUID=1001
 ARG USER_EGID=1001

--- a/scripts/bootstrap-ansible.sh
+++ b/scripts/bootstrap-ansible.sh
@@ -3,7 +3,3 @@
 # minimal bootstrapping before kicking off ansible:
 #  install only what ansible needs to survive, or doesn't know how to do
 sudo dnf -y install python2 python2-dnf libselinux-python
-
-# Install rhsm and its deps from url since they aren't in fedora yet.
-sudo dnf -y install https://kojipkgs.fedoraproject.org//packages/subscription-manager/1.21.4/3.fc29/x86_64/subscription-manager-rhsm-certificates-1.21.4-3.fc29.x86_64.rpm
-sudo dnf -y install https://kojipkgs.fedoraproject.org//packages/subscription-manager/1.21.4/3.fc29/x86_64/python2-subscription-manager-rhsm-1.21.4-3.fc29.x86_64.rpm


### PR DESCRIPTION
- We shouldn't be using fedora:latest. It can change to a newer
  major version at any time, breaking the dev env.
  Right now, fedora:latest is 29 and that's broken since nightly
  repos aren't generated for F29 yet[1].

  Also, the libvirt provider for the dev-env uses F28. It seems
  a good idea for the libvirt and docker providers to be using
  the same major version of fedora.

- The hack for installing subscription manager doesn't seem needed
  any more, F28 has both subscription-manager-rhsm-certificates
  and python2-subscription-manager-rhsm

- Install dnf-utils rather than yum-utils because, on later Fedora,
  dnf-utils and yum-utils conflict.

[1] https://repos.fedorapeople.org/repos/pulp/pulp/testing/automation/2-master/stage/