### PR TITLE
3 different fixes related to repo management

### DIFF
--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -36,7 +36,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       config.hostmanager.manage_host = true
   end
 
-  config.vm.provision "shell", inline: "sudo yum install epel-release"
+  config.vm.provision "shell", inline: "sudo yum install -y epel-release"
 
   # Comment this line if you would like to disable the automatic update during provisioning
   config.vm.provision "shell", inline: "sudo yum upgrade -y"

--- a/ansible/roles/db/tasks/main.yml
+++ b/ansible/roles/db/tasks/main.yml
@@ -1,10 +1,20 @@
 ---
+- name: Add MongoDB3.4 repo
+  yum_repository:
+    name: mongo34
+    description: mongo34 repo
+    file: mongodb34
+    baseurl: https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.4/x86_64/
+    enabled: yes
+    gpgcheck: yes
+    gpgkey: https://www.mongodb.org/static/pgp/server-3.4.asc
+
 - name: Install packages
   yum:
       state: present
       name:
-          - mongodb
-          - mongodb-server
+          - mongodb-org
+          - mongodb-org-server
 
 - name: Disable MongoDB journal
   lineinfile:

--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -24,12 +24,17 @@
       url: https://repos.fedorapeople.org/repos/pulp/pulp/rhel-pulp.repo
       dest: /etc/yum.repos.d/rhel-pulp.repo
 
+- name: Install yum-utils for yum config-manager
+  yum:
+    name: yum-utils
+    state: present
+
 - name: Enable Pulp Nightly repository
-  command: yum config-manager --set-enabled pulp-nightlies
+  command: yum-config-manager --enable pulp-nightlies
   when: pulp_nightly_repo_enabled == false
 
 - name: Disable Pulp Stable repository
-  command: yum config-manager --set-disabled pulp-2-stable
+  command: yum-config-manager --disable pulp-2-stable
 
 # These can go away when https://fedorahosted.org/spin-kickstarts/ticket/59 is fixed
 - stat:

--- a/ansible/roles/pulp/tasks/pulp_server.yaml
+++ b/ansible/roles/pulp/tasks/pulp_server.yaml
@@ -1,10 +1,20 @@
 ---
+- name: Add MongoDB3.4 repo
+  yum_repository:
+    name: mongo34
+    description: mongo34 repo
+    file: mongodb34
+    baseurl: https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.4/x86_64/
+    enabled: yes
+    gpgcheck: yes
+    gpgkey: https://www.mongodb.org/static/pgp/server-3.4.asc
+
 - name: Install MongoDB server
   package:
     state: latest
     name:
-      - mongodb-server
-      - mongodb
+      - mongodb-org-server
+      - mongodb-org
 
 - name: Start and enable MongoDB server service
   service: name=mongod state=started enabled=yes


### PR DESCRIPTION
Most noteworthy is using MongoDB from upstream, similar to what
pulp_installer/pulp-ci pulp2-nightly-pulp3-source-centos7 does,
because EPEL7 no longer includes it.

[noissue]